### PR TITLE
JSI instance may be any type

### DIFF
--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -380,9 +380,9 @@ module JSI
       memoize(:[], property_name_) do |property_name|
         begin
           property_schema = schema.subschema_for_property(property_name)
-          property_schema = property_schema && property_schema.match_to_instance(instance[property_name])
+          property_schema = property_schema && property_schema.match_to_instance(instance_sub(property_name))
 
-          if !instance.key?(property_name) && property_schema && property_schema.schema_object.key?('default')
+          if !instance_hash_pubsend(:key?, property_name) && property_schema && property_schema.schema_object.key?('default')
             # use the default value
             default = property_schema.schema_object['default']
             if default.respond_to?(:to_hash) || default.respond_to?(:to_ary)
@@ -390,10 +390,10 @@ module JSI
             else
               default
             end
-          elsif property_schema && (instance[property_name].respond_to?(:to_hash) || instance[property_name].respond_to?(:to_ary))
-            class_for_schema(property_schema).new(instance[property_name], ancestor: @ancestor)
+          elsif property_schema && (instance_sub(property_name).respond_to?(:to_hash) || instance_sub(property_name).respond_to?(:to_ary))
+            class_for_schema(property_schema).new(instance_sub(property_name), ancestor: @ancestor)
           else
-            instance[property_name]
+            instance_sub(property_name)
           end
         end
       end
@@ -407,6 +407,11 @@ module JSI
     #   property_name
     def []=(property_name, value)
       subscript_assign(property_name, value)
+    end
+
+    private
+    def instance_sub(subscript)
+      instance_hash_pubsend(:[], subscript)
     end
   end
 
@@ -455,9 +460,9 @@ module JSI
       memoize(:[], i_) do |i|
         begin
           index_schema = schema.subschema_for_index(i)
-          index_schema = index_schema && index_schema.match_to_instance(instance[i])
+          index_schema = index_schema && index_schema.match_to_instance(instance_sub(i))
 
-          if !instance.each_index.to_a.include?(i) && index_schema && index_schema.schema_object.key?('default')
+          if !instance_ary_pubsend(:each_index).to_a.include?(i) && index_schema && index_schema.schema_object.key?('default')
             # use the default value
             default = index_schema.schema_object['default']
             if default.respond_to?(:to_hash) || default.respond_to?(:to_ary)
@@ -465,10 +470,10 @@ module JSI
             else
               default
             end
-          elsif index_schema && (instance[i].respond_to?(:to_hash) || instance[i].respond_to?(:to_ary))
-            class_for_schema(index_schema).new(instance[i], ancestor: @ancestor)
+          elsif index_schema && (instance_sub(i).respond_to?(:to_hash) || instance_sub(i).respond_to?(:to_ary))
+            class_for_schema(index_schema).new(instance_sub(i), ancestor: @ancestor)
           else
-            instance[i]
+            instance_sub(i)
           end
         end
       end
@@ -480,6 +485,11 @@ module JSI
     # @param value [Object] the value to be assigned to the given subscript i
     def []=(i, value)
       subscript_assign(i, value)
+    end
+
+    private
+    def instance_sub(subscript)
+      instance_ary_pubsend(:[], subscript)
     end
   end
 end

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -122,7 +122,7 @@ module JSI
     #
     # @return [JSI::Base, self]
     def deref
-      derefed = instance.deref
+      derefed = instance.respond_to?(:deref) ? instance.deref : instance
       if derefed.object_id == instance.object_id
         self
       else

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -102,6 +102,7 @@ module JSI
     #
     # @return [Array<JSI::Base>]
     def parents
+      check_can_get_parents!
       parent = @ancestor
       (@ancestor.instance.path.size...self.instance.path.size).map do |i|
         parent.tap do
@@ -228,6 +229,12 @@ module JSI
         instance[subscript] = value.instance
       else
         instance[subscript] = value
+      end
+    end
+
+    def check_can_get_parents!
+      unless @ancestor && @ancestor.instance.is_a?(JSI::JSON::Node)
+        raise(TypeError, "cannot get parents of JSI for instance that is not a JSI::JSON::Node. please wrap the root of the instance as a JSI::JSON::Node and instantiate from that in order to get parents. instance is: #{instance.pretty_inspect.chomp}")
       end
     end
 

--- a/test/base_array_test.rb
+++ b/test/base_array_test.rb
@@ -166,6 +166,17 @@ describe JSI::BaseArray do
     it('#values_at')            { assert_equal(['foo'], subject.values_at(0)) }
     it('#zip')                  { assert_equal([['foo', 'foo'], [subject[1], subject[1]], [subject[2], subject[2]]], subject.zip(subject)) }
   end
+  describe 'with an instance that has to_ary but not other ary instance methods' do
+    let(:instance) { SortOfArray.new(['foo', {'lamp' => SortOfArray.new([3])}, SortOfArray.new(['q', 'r'])]) }
+    describe 'delegating instance methods to #to_ary' do
+      it('#each_index') { assert_equal([0, 1, 2], subject.each_index.to_a) }
+      it('#size')       { assert_equal(3, subject.size) }
+      it('#count')      { assert_equal(1, subject.count('foo')) }
+      it('#slice')      { assert_equal(['foo'], subject.slice(0, 1)) }
+      it('#[]')         { assert_equal(SortOfArray.new(['q', 'r']), subject[2].instance) }
+      it('#as_json') { assert_equal(['foo', {'lamp' => [3]}, ['q', 'r']], subject.as_json) }
+    end
+  end
   describe 'modified copy methods' do
     it('#reject') { assert_equal(class_for_schema.new(JSI::JSON::ArrayNode.new(['foo'], [])), subject.reject { |e| e != 'foo' }) }
     it('#reject block var') do

--- a/test/base_hash_test.rb
+++ b/test/base_hash_test.rb
@@ -168,6 +168,15 @@ describe JSI::BaseHash do
     it('#values')       { assert_equal([subject['foo'], subject['bar'], true], subject.values) }
     it('#values_at')    { assert_equal([true], subject.values_at('baz')) }
   end
+  describe 'with an instance that has to_hash but not other hash instance methods' do
+    let(:instance) { SortOfHash.new({'foo' => SortOfHash.new({'a' => 'b'})}) }
+    describe 'delegating instance methods to #to_hash' do
+      it('#each_key') { assert_equal(['foo'], subject.each_key.to_a) }
+      it('#each_pair') { assert_equal([['foo', subject['foo']]], subject.each_pair.to_a) }
+      it('#[]') { assert_equal(SortOfHash.new({'a' => 'b'}), subject['foo'].instance) }
+      it('#as_json') { assert_equal({'foo' => {'a' => 'b'}}, subject.as_json) }
+    end
+  end
   describe 'modified copy methods' do
     # I'm going to rely on the #merge test above to test the modified copy functionality and just do basic
     # tests of all the modified copy methods here

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -202,6 +202,19 @@ describe JSI::Base do
     end
   end
   describe '#modified_copy' do
+    describe 'with an instance that does not have #modified_copy' do
+      let(:instance) { Object.new }
+      it 'yields the instance to modify' do
+        new_instance = Object.new
+        modified = subject.modified_copy do |o|
+          assert_equal(instance, o)
+          new_instance
+        end
+        assert_equal(new_instance, modified.instance)
+        assert_equal(instance, subject.instance)
+        refute_equal(instance, modified)
+      end
+    end
     describe 'with an instance that does have #modified_copy' do
       it 'yields the instance to modify' do
         modified = subject.modified_copy do |o|

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -107,7 +107,7 @@ describe JSI::Base do
     describe 'nil' do
       let(:instance) { nil }
       it 'initializes with nil instance' do
-        assert_equal(JSI::JSON::Node.new_doc(nil), subject.instance)
+        assert_equal(nil, subject.instance)
         assert(!subject.respond_to?(:to_ary))
         assert(!subject.respond_to?(:to_hash))
       end
@@ -115,7 +115,7 @@ describe JSI::Base do
     describe 'arbitrary instance' do
       let(:instance) { Object.new }
       it 'initializes' do
-        assert_equal(JSI::JSON::Node.new_doc(instance), subject.instance)
+        assert_equal(instance, subject.instance)
         assert(!subject.respond_to?(:to_ary))
         assert(!subject.respond_to?(:to_hash))
       end
@@ -124,7 +124,7 @@ describe JSI::Base do
       let(:instance) { {'foo' => 'bar'} }
       let(:schema_content) { {'type' => 'object'} }
       it 'initializes' do
-        assert_equal(JSI::JSON::Node.new_doc({'foo' => 'bar'}), subject.instance)
+        assert_equal({'foo' => 'bar'}, subject.instance)
         assert(!subject.respond_to?(:to_ary))
         assert(subject.respond_to?(:to_hash))
       end
@@ -142,7 +142,7 @@ describe JSI::Base do
       let(:instance) { ['foo'] }
       let(:schema_content) { {'type' => 'array'} }
       it 'initializes' do
-        assert_equal(JSI::JSON::Node.new_doc(['foo']), subject.instance)
+        assert_equal(['foo'], subject.instance)
         assert(subject.respond_to?(:to_ary))
         assert(!subject.respond_to?(:to_hash))
       end
@@ -156,14 +156,19 @@ describe JSI::Base do
         assert(!subject.respond_to?(:to_hash))
       end
     end
-    describe 'another Base' do
+    describe 'another JSI::Base invalid' do
       let(:schema_content) { {'type' => 'object'} }
       let(:instance) { JSI.class_for_schema(schema).new({'foo' => 'bar'}) }
-      it 'initializes with a warning' do
-        assert_output(nil, /assigning instance to a Base instance is incorrect. received: #\{<JSI::SchemaClasses\["[^"]+#"\][^>]*>[^}]+}/) do
-          subject
-        end
-        assert_equal(JSI::JSON::HashNode.new({'foo' => 'bar'}, []), subject.instance)
+      it 'initializes with an error' do
+        err = assert_raises(TypeError) { subject }
+        assert_match(%r(\Aassigning another JSI::Base instance to JSI::SchemaClasses\[\".*#\"\] instance is incorrect. received: #\{<JSI::SchemaClasses\[.*\] Hash>\s*"foo" => "bar"\s*\}\z)m, err.message)
+      end
+    end
+    describe 'Schema invalid' do
+      let(:instance) { JSI::Schema.new({}) }
+      it 'initializes with an error' do
+        err = assert_raises(TypeError) { subject }
+        assert_match(%r(\Aassigning a schema to JSI::SchemaClasses\[\".*#\"\] instance is incorrect. received: #<JSI::Schema schema_id=.*>\z)m, err.message)
       end
     end
   end


### PR DESCRIPTION
no reason for a JSI's #instance to just be a JSI::JSON::Node. undesirable in fact. this allows a plain hash/array, or any other type that responds to #to_hash / #to_ary 