### PR TITLE
rm Schema#describes_array? and Schema#describes_hash?

### DIFF
--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -219,26 +219,24 @@ module JSI
             %Q(#<Module for Schema: #{schema_id}>)
           end
 
-          if schema.describes_object?
-            instance_method_modules = [m, Base, BaseArray, BaseHash]
-            instance_methods = instance_method_modules.map do |mod|
-              mod.instance_methods + mod.private_instance_methods
-            end.inject(Set.new, &:|)
-            accessors_to_define = schema.described_hash_property_names.map(&:to_s) - instance_methods.map(&:to_s)
-            accessors_to_define.each do |property_name|
-              define_method(property_name) do
-                if respond_to?(:[])
-                  self[property_name]
-                else
-                  raise(NoMethodError, "instance does not respond to []; cannot call reader `#{property_name}' for: #{pretty_inspect.chomp}")
-                end
+          instance_method_modules = [m, Base, BaseArray, BaseHash]
+          instance_methods = instance_method_modules.map do |mod|
+            mod.instance_methods + mod.private_instance_methods
+          end.inject(Set.new, &:|)
+          accessors_to_define = schema.described_hash_property_names.map(&:to_s) - instance_methods.map(&:to_s)
+          accessors_to_define.each do |property_name|
+            define_method(property_name) do
+              if respond_to?(:[])
+                self[property_name]
+              else
+                raise(NoMethodError, "instance does not respond to []; cannot call reader `#{property_name}' for: #{pretty_inspect.chomp}")
               end
-              define_method("#{property_name}=") do |value|
-                if respond_to?(:[]=)
-                  self[property_name] = value
-                else
-                  raise(NoMethodError, "instance does not respond to []=; cannot call writer `#{property_name}=' for: #{pretty_inspect.chomp}")
-                end
+            end
+            define_method("#{property_name}=") do |value|
+              if respond_to?(:[]=)
+                self[property_name] = value
+              else
+                raise(NoMethodError, "instance does not respond to []=; cannot call writer `#{property_name}=' for: #{pretty_inspect.chomp}")
               end
             end
           end

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -219,7 +219,7 @@ module JSI
             %Q(#<Module for Schema: #{schema_id}>)
           end
 
-          if schema.describes_hash?
+          if schema.describes_object?
             instance_method_modules = [m, Base, BaseArray, BaseHash]
             instance_methods = instance_method_modules.map do |mod|
               mod.instance_methods + mod.private_instance_methods

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -148,6 +148,9 @@ module JSI
       end
     end
 
+    # @return [Boolean] whether this schema appears to describe an array,
+    #   either from its `type` or the presence of properties that only make
+    #   sense for an array type.
     def describes_array?
       memoize(:describes_array?) do
         schema_node['type'] == 'array' ||
@@ -166,6 +169,10 @@ module JSI
             schema_node['anyOf'].all? { |someof_node| self.class.new(someof_node).describes_array? }
       end
     end
+
+    # @return [Boolean] whether this schema appears to describe a json object
+    #   (ruby hash), either from its property "type" or the presence of
+    #   properties which only make sense for an object/hash type.
     def describes_hash?
       memoize(:describes_hash?) do
         schema_node['type'] == 'object' ||

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -173,8 +173,8 @@ module JSI
     # @return [Boolean] whether this schema appears to describe a json object
     #   (ruby hash), either from its property "type" or the presence of
     #   properties which only make sense for an object/hash type.
-    def describes_hash?
-      memoize(:describes_hash?) do
+    def describes_object?
+      memoize(:describes_object?) do
         schema_node['type'] == 'object' ||
           schema_node['required'].respond_to?(:to_ary) ||
           schema_node['properties'].respond_to?(:to_hash) ||
@@ -183,11 +183,11 @@ module JSI
           schema_node['default'].respond_to?(:to_hash) ||
           (schema_node['enum'].respond_to?(:to_ary) && schema_node['enum'].all? { |enum| enum.respond_to?(:to_hash) }) ||
           schema_node['oneOf'].respond_to?(:to_ary) &&
-            schema_node['oneOf'].all? { |someof_node| self.class.new(someof_node).describes_hash? } ||
+            schema_node['oneOf'].all? { |someof_node| self.class.new(someof_node).describes_object? } ||
           schema_node['allOf'].respond_to?(:to_ary) &&
-            schema_node['allOf'].all? { |someof_node| self.class.new(someof_node).describes_hash? } ||
+            schema_node['allOf'].all? { |someof_node| self.class.new(someof_node).describes_object? } ||
           schema_node['anyOf'].respond_to?(:to_ary) &&
-            schema_node['anyOf'].all? { |someof_node| self.class.new(someof_node).describes_hash? }
+            schema_node['anyOf'].all? { |someof_node| self.class.new(someof_node).describes_object? }
       end
     end
 

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -148,49 +148,6 @@ module JSI
       end
     end
 
-    # @return [Boolean] whether this schema appears to describe an array,
-    #   either from its `type` or the presence of properties that only make
-    #   sense for an array type.
-    def describes_array?
-      memoize(:describes_array?) do
-        schema_node['type'] == 'array' ||
-          schema_node['items'] ||
-          schema_node['additionalItems'] ||
-          schema_node['default'].respond_to?(:to_ary) || # TODO make sure this is right
-          (schema_node['enum'].respond_to?(:to_ary) && schema_node['enum'].all? { |enum| enum.respond_to?(:to_ary) }) ||
-          schema_node['maxItems'] ||
-          schema_node['minItems'] ||
-          schema_node.key?('uniqueItems') ||
-          schema_node['oneOf'].respond_to?(:to_ary) &&
-            schema_node['oneOf'].all? { |someof_node| self.class.new(someof_node).describes_array? } ||
-          schema_node['allOf'].respond_to?(:to_ary) &&
-            schema_node['allOf'].all? { |someof_node| self.class.new(someof_node).describes_array? } ||
-          schema_node['anyOf'].respond_to?(:to_ary) &&
-            schema_node['anyOf'].all? { |someof_node| self.class.new(someof_node).describes_array? }
-      end
-    end
-
-    # @return [Boolean] whether this schema appears to describe a json object
-    #   (ruby hash), either from its property "type" or the presence of
-    #   properties which only make sense for an object/hash type.
-    def describes_object?
-      memoize(:describes_object?) do
-        schema_node['type'] == 'object' ||
-          schema_node['required'].respond_to?(:to_ary) ||
-          schema_node['properties'].respond_to?(:to_hash) ||
-          schema_node['additionalProperties'] ||
-          schema_node['patternProperties'] ||
-          schema_node['default'].respond_to?(:to_hash) ||
-          (schema_node['enum'].respond_to?(:to_ary) && schema_node['enum'].all? { |enum| enum.respond_to?(:to_hash) }) ||
-          schema_node['oneOf'].respond_to?(:to_ary) &&
-            schema_node['oneOf'].all? { |someof_node| self.class.new(someof_node).describes_object? } ||
-          schema_node['allOf'].respond_to?(:to_ary) &&
-            schema_node['allOf'].all? { |someof_node| self.class.new(someof_node).describes_object? } ||
-          schema_node['anyOf'].respond_to?(:to_ary) &&
-            schema_node['anyOf'].all? { |someof_node| self.class.new(someof_node).describes_object? }
-      end
-    end
-
     def described_hash_property_names
       memoize(:described_hash_property_names) do
         Set.new.tap do |property_names|


### PR DESCRIPTION
remove Schema#describes_array? and Schema#describes_hash? - these methods are not too good and not too needed

easy enough to restore in the future if they seem of any value.