### PR TITLE
don't stringify hash keys in Base#initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Now `user.contacts` will return an array of Contact instances, from the json typ
 
 ## Keying Hashes (JSON Objects)
 
-Unlike Ruby, JSON only supports string keys. JSI converts symbols to strings for its internal hash keys (much like ActiveSupport::HashWithIndifferentAccess). JSI accepts symbols to refer to its string hash keys for instantiation, but does not currently transform symbols to strings everywhere else, e.g. `bill[:name]` is `nil` whereas `bill['name']` is `"bill"`.
+Unlike Ruby, JSON only supports string keys. It is recommended to use strings as hash keys for all JSI instances, but JSI does not enforce this, nor does it do any key conversion. It should be possible to use ActiveSupport::HashWithIndifferentAccess as the instance of a JSI in order to gain the benefits that offers over a plain hash. This is not tested behavior, but JSI should behave correctly with any instance that responds to #to_hash.
 
 ## Contributing
 

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -145,11 +145,11 @@ module JSI
       end
       if thing.is_a?(Base)
         warn "assigning instance to a Base instance is incorrect. received: #{thing.pretty_inspect.chomp}"
-        @instance = JSI.deep_stringify_symbol_keys(thing.instance)
+        @instance = thing.instance
       elsif thing.is_a?(JSI::JSON::Node)
-        @instance = JSI.deep_stringify_symbol_keys(thing)
+        @instance = thing
       else
-        @instance = JSI::JSON::Node.new_doc(JSI.deep_stringify_symbol_keys(thing))
+        @instance = JSI::JSON::Node.new_doc(thing)
       end
     end
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -168,8 +168,8 @@ describe JSI::Base do
     end
   end
   describe '#parents, #parent' do
-    let(:schema_content) { {properties: {foo: {properties: {bar: {properties: {baz: {}}}}}}} }
-    let(:document) { {foo: {bar: {baz: {}}}} }
+    let(:schema_content) { {'properties' => {'foo' => {'properties' => {'bar' => {'properties' => {'baz' => {}}}}}}} }
+    let(:document) { {'foo' => {'bar' => {'baz' => {}}}} }
     describe 'no parents' do
       it 'has none' do
         assert_equal([], subject.parents)

--- a/test/schema_instance_json_coder_test.rb
+++ b/test/schema_instance_json_coder_test.rb
@@ -10,7 +10,7 @@ describe JSI::SchemaInstanceJSONCoder do
         assert_nil(schema_instance_json_coder.load(nil))
       end
       it 'loads a hash' do
-        assert_equal(schema_instance_class.new(foo: 'bar'), schema_instance_json_coder.load({"foo" => "bar"}))
+        assert_equal(schema_instance_class.new('foo' => 'bar'), schema_instance_json_coder.load({"foo" => "bar"}))
       end
       it 'loads something else' do
         assert_equal(schema_instance_class.new([[]]), schema_instance_json_coder.load([[]]))
@@ -19,7 +19,7 @@ describe JSI::SchemaInstanceJSONCoder do
         let(:options) { {array: true} }
         it 'loads an array of hashes' do
           data = [{"foo" => "bar"}, {"foo" => "baz"}]
-          assert_equal([schema_instance_class.new(foo: 'bar'), schema_instance_class.new(foo: 'baz')], schema_instance_json_coder.load(data))
+          assert_equal([schema_instance_class.new('foo' => 'bar'), schema_instance_class.new('foo' => 'baz')], schema_instance_json_coder.load(data))
         end
         it 'loads an empty array' do
           assert_equal([], schema_instance_json_coder.load([]))
@@ -65,7 +65,7 @@ describe JSI::SchemaInstanceJSONCoder do
         assert_nil(schema_instance_json_coder.load(nil))
       end
       it 'loads a hash' do
-        assert_equal(schema_instance_class.new(foo: 'bar'), schema_instance_json_coder.load('{"foo": "bar"}'))
+        assert_equal(schema_instance_class.new('foo' => 'bar'), schema_instance_json_coder.load('{"foo": "bar"}'))
       end
       it 'loads something else' do
         assert_equal(schema_instance_class.new([[]]), schema_instance_json_coder.load('[[]]'))
@@ -79,7 +79,7 @@ describe JSI::SchemaInstanceJSONCoder do
         let(:options) { {string: true, array: true} }
         it 'loads an array of hashes' do
           data = '[{"foo": "bar"}, {"foo": "baz"}]'
-          assert_equal([schema_instance_class.new(foo: 'bar'), schema_instance_class.new(foo: 'baz')], schema_instance_json_coder.load(data))
+          assert_equal([schema_instance_class.new('foo' => 'bar'), schema_instance_class.new('foo' => 'baz')], schema_instance_json_coder.load(data))
         end
         it 'loads an empty array' do
           assert_equal([], schema_instance_json_coder.load('[]'))

--- a/test/util_test.rb
+++ b/test/util_test.rb
@@ -10,7 +10,7 @@ describe JSI::Util do
       expected = JSI::JSON::HashNode.new({'a' => 'b', 'c' => 'd', nil => 3}, [])
       assert_equal(expected, actual)
     end
-    it 'stringifies SchemaObjectBase hash keys' do
+    it 'stringifies JSI hash keys' do
       klass = JSI.class_for_schema(type: 'object')
       expected = JSI.stringify_symbol_keys(klass.new(JSI::JSON::HashNode.new({a: 'b', 'c' => 'd', nil => 3}, [])))
       actual = klass.new(JSI::JSON::HashNode.new({'a' => 'b', 'c' => 'd', nil => 3}, []))
@@ -52,10 +52,10 @@ describe JSI::Util do
       expected = JSI::JSON::HashNode.new({'a' => 'b', 'c' => {'d' => 0}, nil => 3}, [])
       assert_equal(expected, actual)
     end
-    it 'deep stringifies SchemaObjectBase instance on initialize' do
+    it 'deep stringifies JSI instance' do
       klass = JSI.class_for_schema(type: 'object')
-      expected = klass.new(JSI::JSON::HashNode.new({a: 'b', 'c' => {d: 0}, nil => 3}, []))
-      actual = klass.new(JSI::JSON::HashNode.new({'a' => 'b', 'c' => {'d' => 0}, nil => 3}, []))
+      actual = JSI.deep_stringify_symbol_keys(klass.new(JSI::JSON::HashNode.new({a: 'b', 'c' => {d: 0}, nil => 3}, [])))
+      expected = klass.new(JSI::JSON::HashNode.new({'a' => 'b', 'c' => {'d' => 0}, nil => 3}, []))
       assert_equal(expected, actual)
     end
   end


### PR DESCRIPTION
while it may arguably be better for a JSI to treat hash keys that are symbols as if they were strings, calling deep_stringify_symbol_keys in Base#initialize is, for one thing, very much a half-assed solution since `some_jsi[:foo]` is not the same as `some_jsi['foo']`, and also problematic in that the JSI's instance then may or may not refer to the same actual object as the instance that was passed to #initialize.

in the future I _might_ decide that Base#initialize does a deep stringifying copy of its instance _if_ I fully implement something more like ActiveSupport::HashWithIndifferentAccess within JSI::Base. but I kind of doubt it.