### PR TITLE
misc

### DIFF
--- a/lib/jsi/json/node.rb
+++ b/lib/jsi/json/node.rb
@@ -45,6 +45,9 @@ module JSI
       # a Node represents the content of a document at a given path.
       def initialize(document, path)
         raise(ArgumentError, "path must be an array. got: #{path.pretty_inspect.chomp} (#{path.class})") unless path.is_a?(Array)
+        if document.is_a?(JSI::JSON::Node)
+          raise(TypeError, "document of a Node should not be another JSI::JSON::Node: #{document.inspect}")
+        end
         @document = document
         @path = path.dup.freeze
         @pointer = ::JSON::Schema::Pointer.new(:reference_tokens, path)

--- a/lib/jsi/json/node.rb
+++ b/lib/jsi/json/node.rb
@@ -81,7 +81,7 @@ module JSI
         begin
           subcontent = content[subscript]
         rescue TypeError => e
-          raise(e.class, e.message + "\nsubscripting with #{subscript.pretty_inspect.chomp} (#{subscript.class}) from #{content.class.inspect}. self is: #{pretty_inspect.chomp}", e.backtrace)
+          raise(e.class, e.message + "\nsubscripting with #{subscript.pretty_inspect.chomp} (#{subscript.class}) from #{content.class.inspect}. content is: #{content.pretty_inspect.chomp}", e.backtrace)
         end
         if subcontent.respond_to?(:to_hash)
           HashNode.new(node.document, node.path + [subscript])

--- a/lib/jsi/json/node.rb
+++ b/lib/jsi/json/node.rb
@@ -44,12 +44,14 @@ module JSI
 
       # a Node represents the content of a document at a given path.
       def initialize(document, path)
-        raise(ArgumentError, "path must be an array. got: #{path.pretty_inspect.chomp} (#{path.class})") unless path.is_a?(Array)
+        unless path.respond_to?(:to_ary)
+          raise(ArgumentError, "path must be an array. got: #{path.pretty_inspect.chomp} (#{path.class})")
+        end
         if document.is_a?(JSI::JSON::Node)
           raise(TypeError, "document of a Node should not be another JSI::JSON::Node: #{document.inspect}")
         end
         @document = document
-        @path = path.dup.freeze
+        @path = path.to_ary.dup.freeze
         @pointer = ::JSON::Schema::Pointer.new(:reference_tokens, path)
       end
 

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -24,13 +24,6 @@ module JSI
       else
         raise(TypeError, "cannot instantiate Schema from: #{schema_object.pretty_inspect.chomp}")
       end
-      if @schema_jsi
-        define_singleton_method(:instance) { schema_node } # aka schema_jsi.instance
-        define_singleton_method(:schema) { schema_jsi.schema }
-        extend BaseHash
-      else
-        define_singleton_method(:[]) { |*a, &b| schema_node.public_send(:[], *a, &b) }
-      end
     end
 
     # @return [JSI::JSON::Node] a JSI::JSON::Node for the schema
@@ -43,6 +36,12 @@ module JSI
     #   JSI::JSON::Node for the schema
     def schema_object
       @schema_jsi || @schema_node
+    end
+
+    # @return [JSI::Base, JSI::JSON::Node, Object] property value from the schema_object
+    # @param property_name [String, Object] property name to access from the schema_object
+    def [](property_name)
+      schema_object[property_name]
     end
 
     # @return [String] an absolute id for the schema, with a json pointer fragment

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -205,12 +205,12 @@ module JSI
     # @return [Array<String>] array of schema validation error messages for
     #   the given instance against this schema
     def fully_validate(instance)
-      ::JSON::Validator.fully_validate(schema_node.document, object_to_content(instance), fragment: schema_node.fragment)
+      ::JSON::Validator.fully_validate(JSI::Typelike.as_json(schema_node.document), JSI::Typelike.as_json(instance), fragment: schema_node.fragment)
     end
 
     # @return [true, false] whether the given instance validates against this schema
     def validate(instance)
-      ::JSON::Validator.validate(schema_node.document, object_to_content(instance), fragment: schema_node.fragment)
+      ::JSON::Validator.validate(JSI::Typelike.as_json(schema_node.document), JSI::Typelike.as_json(instance), fragment: schema_node.fragment)
     end
 
     # @return [true] if this method does not raise, it returns true to
@@ -218,19 +218,19 @@ module JSI
     # @raise [::JSON::Schema::ValidationError] raises if the instance has
     #   validation errors against this schema
     def validate!(instance)
-      ::JSON::Validator.validate!(schema_node.document, object_to_content(instance), fragment: schema_node.fragment)
+      ::JSON::Validator.validate!(JSI::Typelike.as_json(schema_node.document), JSI::Typelike.as_json(instance), fragment: schema_node.fragment)
     end
 
     # @return [Array<String>] array of schema validation error messages for
     #   this schema, validated against its metaschema. a default metaschema
     #   is assumed if the schema does not specify a $schema.
     def fully_validate_schema
-      ::JSON::Validator.fully_validate(schema_node.document, [], fragment: schema_node.fragment, validate_schema: true, list: true)
+      ::JSON::Validator.fully_validate(JSI::Typelike.as_json(schema_node.document), [], fragment: schema_node.fragment, validate_schema: true, list: true)
     end
 
     # @return [true, false] whether this schema validates against its metaschema
     def validate_schema
-      ::JSON::Validator.validate(schema_node.document, [], fragment: schema_node.fragment, validate_schema: true, list: true)
+      ::JSON::Validator.validate(JSI::Typelike.as_json(schema_node.document), [], fragment: schema_node.fragment, validate_schema: true, list: true)
     end
 
     # @return [true] if this method does not raise, it returns true to
@@ -238,7 +238,7 @@ module JSI
     # @raise [::JSON::Schema::ValidationError] raises if this schema has
     #   validation errors against its metaschema
     def validate_schema!
-      ::JSON::Validator.validate!(schema_node.document, [], fragment: schema_node.fragment, validate_schema: true, list: true)
+      ::JSON::Validator.validate!(JSI::Typelike.as_json(schema_node.document), [], fragment: schema_node.fragment, validate_schema: true, list: true)
     end
 
     # @return [String] a string for #instance and #pretty_print including the schema_id
@@ -278,12 +278,5 @@ module JSI
       {class: self.class, schema_node: schema_node}
     end
     include FingerprintHash
-
-    private
-    def object_to_content(object)
-      object = object.instance if object.is_a?(JSI::Base)
-      object = object.content if object.is_a?(JSI::JSON::Node)
-      object
-    end
   end
 end

--- a/test/jsi_json_arraynode_test.rb
+++ b/test/jsi_json_arraynode_test.rb
@@ -13,7 +13,7 @@ describe JSI::JSON::ArrayNode do
       err = assert_raises(TypeError) do
         node[:x]
       end
-      assert_match(/^subscripting with :x \(Symbol\) from Array. self is: #\[<JSI::JSON::ArrayNode fragment="#">/, err.message)
+      assert_match(/^subscripting with :x \(Symbol\) from Array. content is: \[.*\]\z/m, err.message)
     end
   end
   describe '#each' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,12 @@ Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 require 'byebug'
 
 class JSISpec < Minitest::Spec
+  if ENV['JSI_TEST_ALPHA']
+    # :nocov:
+    define_singleton_method(:test_order) { :alpha }
+    # :nocov:
+  end
+
   def assert_equal exp, act, msg = nil
     msg = message(msg, E) { diff exp, act }
     assert exp == act, msg


### PR DESCRIPTION
misc fixes
- add test configuration ENV['JSI_TEST_ALPHA']
- drop, for now, the incomplete idea of a schema acting like a JSI::BaseHash when it has a schema_jsi
- Node type check that document is not another Node
- schema validations will use as_json before passing off to JSON::Validator
- when Node#[] raises TypeError, don't let call #pretty_inspect on self since that calls #[] in a recursive fashion
