### PR TITLE
bugfix JSI::Base.name

### DIFF
--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -55,7 +55,7 @@ module JSI
 
       # @return [String] a constant name of this class
       def name
-        unless super
+        unless super || SchemaClasses.const_defined?(schema_classes_const_name)
           SchemaClasses.const_set(schema_classes_const_name, self)
         end
         super


### PR DESCRIPTION
Base.name will not set the SchemaClasses constant if it exists. sometimes Class#name seems to return nil even when the class has been assigned to a constant. weird.

this is only a thing I have noticed when using autocompletion in irb. it invokes #name, as you'd expect, but Class#name is returning nil.

I could check that the const_get for schema_classes_const_name is == self, but I think that's unnecessary.