### PR TITLE
JSIs with the same instance content are considered equal

### DIFF
--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -198,7 +198,10 @@ module JSI
 
     # @return [Object] an opaque fingerprint of this JSI for FingerprintHash
     def fingerprint
-      {class: self.class, instance: instance}
+      {
+        class: self.class,
+        instance: instance.is_a?(JSON::Node) ? {class: JSON::Node, content: instance.content} : instance,
+      }
     end
     include FingerprintHash
 


### PR DESCRIPTION
not sure about this one. a JSON::Node checks the document and its path and considers two nodes at different paths to be unequal, but for JSI::Base I think the path is not worth taking into consideration.

minor note: bit of future-proofing with the JSON::Node type check even though right now all instances are JSON::Node. this may not be true soon.