### PR TITLE
minor refactor

### DIFF
--- a/lib/jsi/json-schema-fragments.rb
+++ b/lib/jsi/json-schema-fragments.rb
@@ -83,7 +83,7 @@ module JSON
       # takes a root json document and evaluates this pointer through the document, returning the value
       # pointed to by this pointer.
       def evaluate(document)
-        reference_tokens.inject(document) do |value, token|
+        res = reference_tokens.inject(document) do |value, token|
           if value.respond_to?(:to_ary)
             if token.is_a?(String) && token =~ /\A\d|[1-9]\d+\z/
               token = token.to_i
@@ -104,6 +104,7 @@ module JSON
             raise(ReferenceError, "Invalid resolution for #{to_s}: #{token.inspect} cannot be resolved in #{value.inspect}")
           end
         end
+        res
       end
 
       # the pointer string representation of this Pointer

--- a/lib/jsi/json/node.rb
+++ b/lib/jsi/json/node.rb
@@ -64,7 +64,8 @@ module JSI
 
       # the raw content of this Node from the underlying document at this Node's path.
       def content
-        pointer.evaluate(document)
+        content = pointer.evaluate(document)
+        content
       end
 
       # returns content at the given subscript - call this the subcontent.


### PR DESCRIPTION
assign return value to local var before return because 'next' in byebug seems to have troubles without it.