### PR TITLE
JSON::Node naming

### DIFF
--- a/test/base_array_test.rb
+++ b/test/base_array_test.rb
@@ -147,8 +147,8 @@ describe JSI::BaseArray do
     # compare:
     # assoc:  https://github.com/ruby/ruby/blob/v2_5_0/array.c#L3780-L3813
     # rassoc: https://github.com/ruby/ruby/blob/v2_5_0/array.c#L3815-L3847
-    # for this reason, rassoc is NOT defined on Arraylike and #content must be called.
-    it('#rassoc')              { assert_equal(['q', 'r'], subject.instance.content.rassoc('r')) }
+    # for this reason, rassoc is NOT defined on Arraylike and #node_content must be called.
+    it('#rassoc')              { assert_equal(['q', 'r'], subject.instance.node_content.rassoc('r')) }
     it('#repeated_combination') { assert_equal([[]], subject.repeated_combination(0).to_a) }
     it('#repeated_permutation') { assert_equal([[]], subject.repeated_permutation(0).to_a) }
     it('#reverse')             { assert_equal([subject[2], subject[1], 'foo'], subject.reverse) }

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -73,7 +73,7 @@ describe JSI::Base do
       assert_operator(class_for_schema, :<, JSI::Base)
     end
     it 'returns a class from a hash' do
-      assert_equal(JSI.class_for_schema(schema), JSI.class_for_schema(schema.schema_node.content))
+      assert_equal(JSI.class_for_schema(schema), JSI.class_for_schema(schema.schema_node.node_content))
     end
     it 'returns a class from a schema node' do
       assert_equal(JSI.class_for_schema(schema), JSI.class_for_schema(schema.schema_node))
@@ -89,7 +89,7 @@ describe JSI::Base do
       assert_equal(JSI::SchemaClasses.module_for_schema(schema), module_for_schema)
     end
     it 'returns a module from a hash' do
-      assert_equal(JSI::SchemaClasses.module_for_schema(schema), JSI::SchemaClasses.module_for_schema(schema.schema_node.content))
+      assert_equal(JSI::SchemaClasses.module_for_schema(schema), JSI::SchemaClasses.module_for_schema(schema.schema_node.node_content))
     end
     it 'returns a module from a schema node' do
       assert_equal(JSI::SchemaClasses.module_for_schema(schema), JSI::SchemaClasses.module_for_schema(schema.schema_node))
@@ -228,8 +228,8 @@ describe JSI::Base do
           assert_equal({}, o)
           {'a' => 'b'}
         end
-        assert_equal({'a' => 'b'}, modified.instance.content)
-        assert_equal({}, subject.instance.content)
+        assert_equal({'a' => 'b'}, modified.instance.node_content)
+        assert_equal({}, subject.instance.node_content)
         refute_equal(instance, modified)
       end
     end
@@ -237,7 +237,7 @@ describe JSI::Base do
       it 'yields the instance to modify' do
         modified = subject.modified_copy { |o| o }
         # this doesn't really need to be tested but ... whatever
-        assert_equal(subject.instance.content.object_id, modified.instance.content.object_id)
+        assert_equal(subject.instance.node_content.object_id, modified.instance.node_content.object_id)
         assert_equal(subject, modified)
         refute_equal(subject.object_id, modified.object_id)
       end
@@ -249,8 +249,8 @@ describe JSI::Base do
         modified = subject.modified_copy do |o|
           o.to_s
         end
-        assert_equal('{}', modified.instance.content)
-        assert_equal({}, subject.instance.content)
+        assert_equal('{}', modified.instance.node_content)
+        assert_equal({}, subject.instance.node_content)
         refute_equal(instance, modified)
         # interesting side effect
         assert(subject.respond_to?(:to_hash))

--- a/test/jsi_json_arraynode_test.rb
+++ b/test/jsi_json_arraynode_test.rb
@@ -3,24 +3,24 @@ require_relative 'test_helper'
 document_types = [
   {
     make_document: -> (d) { d },
-    document: ['a', ['b', 'q'], {'c' => {'d' => 'e'}}],
+    node_document: ['a', ['b', 'q'], {'c' => {'d' => 'e'}}],
     type_desc: 'Array',
   },
   {
     make_document: -> (d) { SortOfArray.new(d) },
-    document: SortOfArray.new(['a', SortOfArray.new(['b', 'q']), SortOfHash.new({'c' => SortOfHash.new({'d' => 'e'})})]),
+    node_document: SortOfArray.new(['a', SortOfArray.new(['b', 'q']), SortOfHash.new({'c' => SortOfHash.new({'d' => 'e'})})]),
     type_desc: 'sort of Array-like',
   },
 ]
 document_types.each do |document_type|
   describe "JSI::JSON::ArrayNode with #{document_type[:type_desc]}" do
-    # document of the node being tested
-    let(:document) { document_type[:document] }
+    # node_document of the node being tested
+    let(:node_document) { document_type[:node_document] }
     # by default the node is the whole document
     let(:path) { [] }
-    let(:pointer) { JSI::JSON::Pointer.new(path) }
+    let(:node_ptr) { JSI::JSON::Pointer.new(path) }
     # the node being tested
-    let(:node) { JSI::JSON::Node.new_by_type(document, pointer) }
+    let(:node) { JSI::JSON::Node.new_by_type(node_document, node_ptr) }
 
     describe '#[] bad index' do
       it 'improves TypeError for Array subsript' do
@@ -56,7 +56,7 @@ document_types.each do |document_type|
       end
     end
     describe '#as_json' do
-      let(:document) { document_type[:make_document].call(['a', 'b']) }
+      let(:node_document) { document_type[:make_document].call(['a', 'b']) }
       it '#as_json' do
         assert_equal(['a', 'b'], node.as_json)
         assert_equal(['a', 'b'], node.as_json(some_option: false))
@@ -130,13 +130,13 @@ document_types.each do |document_type|
     describe 'modified copy methods' do
       it('#reject')  { assert_equal(JSI::JSON::Node.new_doc(['a']), node.reject { |e| e != 'a' }) }
       it('#select')  { assert_equal(JSI::JSON::Node.new_doc(['a']), node.select { |e| e == 'a' }) }
-      it('#compact') { assert_equal(JSI::JSON::Node.new_doc(node.content.to_ary), node.compact) }
+      it('#compact') { assert_equal(JSI::JSON::Node.new_doc(node.node_content.to_ary), node.compact) }
       describe 'at a depth' do
-        let(:document) { document_type[:make_document].call([['b', 'q'], {'c' => ['d', 'e']}]) }
+        let(:node_document) { document_type[:make_document].call([['b', 'q'], {'c' => ['d', 'e']}]) }
         let(:path) { ['1', 'c'] }
         it('#select') do
           selected = node.select { |e| e == 'd' }
-          equivalent = JSI::JSON::Node.new_by_type([['b', 'q'], {'c' => ['d']}], pointer)
+          equivalent = JSI::JSON::Node.new_by_type([['b', 'q'], {'c' => ['d']}], node_ptr)
           assert_equal(equivalent, selected)
         end
       end

--- a/test/jsi_json_node_test.rb
+++ b/test/jsi_json_node_test.rb
@@ -2,75 +2,70 @@ require_relative 'test_helper'
 
 describe JSI::JSON::Node do
   let(:path) { [] }
-  let(:pointer) { JSI::JSON::Pointer.new(path) }
-  let(:node) { JSI::JSON::Node.new(document, pointer) }
+  let(:node_ptr) { JSI::JSON::Pointer.new(path) }
+  let(:node) { JSI::JSON::Node.new(node_document, node_ptr) }
 
   describe 'initialization' do
     it 'initializes' do
-      node = JSI::JSON::Node.new({'a' => 'b'}, pointer)
-      assert_equal({'a' => 'b'}, node.document)
-      assert_equal(JSI::JSON::Pointer.new([]), node.pointer)
+      node = JSI::JSON::Node.new({'a' => 'b'}, node_ptr)
+      assert_equal({'a' => 'b'}, node.node_document)
+      assert_equal(JSI::JSON::Pointer.new([]), node.node_ptr)
     end
-    it 'initializes, pointer is not pointer' do
+    it 'initializes, node_ptr is not node_ptr' do
       err = assert_raises(TypeError) { JSI::JSON::Node.new({'a' => 'b'}, []) }
-      assert_equal('pointer must be a JSI::JSON::Pointer. got: [] (Array)', err.message)
+      assert_equal('node_ptr must be a JSI::JSON::Pointer. got: [] (Array)', err.message)
     end
-    it 'initializes, document is another Node' do
-      err = assert_raises(TypeError) { JSI::JSON::Node.new(JSI::JSON::Node.new({'a' => 'b'}, pointer), pointer) }
-      assert_equal("document of a Node should not be another JSI::JSON::Node: #<JSI::JSON::Node fragment=\"#\" {\"a\"=>\"b\"}>", err.message)
+    it 'initializes, node_document is another Node' do
+      err = assert_raises(TypeError) { JSI::JSON::Node.new(JSI::JSON::Node.new({'a' => 'b'}, node_ptr), node_ptr) }
+      assert_equal("node_document of a Node should not be another JSI::JSON::Node: #<JSI::JSON::Node fragment=\"#\" {\"a\"=>\"b\"}>", err.message)
     end
   end
   describe 'initialization by .new_by_type' do
     it 'initializes HashNode' do
       node = JSI::JSON::Node.new_doc({'a' => 'b'})
       assert_instance_of(JSI::JSON::HashNode, node)
-      assert_equal({'a' => 'b'}, node.document)
+      assert_equal({'a' => 'b'}, node.node_document)
     end
     it 'initializes ArrayNode' do
       node = JSI::JSON::Node.new_doc(['a', 'b'])
       assert_instance_of(JSI::JSON::ArrayNode, node)
-      assert_equal(['a', 'b'], node.document)
+      assert_equal(['a', 'b'], node.node_document)
     end
     it 'initializes Node' do
       object = Object.new
       node = JSI::JSON::Node.new_doc(object)
       assert_instance_of(JSI::JSON::Node, node)
-      assert_equal(object, node.document)
+      assert_equal(object, node.node_document)
     end
   end
-  describe '#pointer' do
+  describe '#node_ptr' do
     it 'is a JSI::JSON::Pointer' do
-      assert_instance_of(JSI::JSON::Pointer, JSI::JSON::Node.new({}, pointer).pointer)
+      assert_instance_of(JSI::JSON::Pointer, JSI::JSON::Node.new({}, node_ptr).node_ptr)
     end
   end
-  describe '#path' do
-    it 'is an array of reference tokens' do
-      assert_equal(['a'], JSI::JSON::Node.new({}, JSI::JSON::Pointer.new(['a'])).path)
+  describe '#node_content' do
+    it 'returns the node_content at the root' do
+      assert_equal({'a' => 'b'}, JSI::JSON::Node.new({'a' => 'b'}, node_ptr).node_content)
     end
-  end
-  describe '#content' do
-    it 'returns the content at the root' do
-      assert_equal({'a' => 'b'}, JSI::JSON::Node.new({'a' => 'b'}, pointer).content)
-    end
-    it 'returns the content from the deep' do
-      assert_equal('b', JSI::JSON::Node.new([0, {'x' => [{'a' => ['b']}]}], JSI::JSON::Pointer.new([1, 'x', 0, 'a', 0])).content)
+    it 'returns the node_content from the deep' do
+      assert_equal('b', JSI::JSON::Node.new([0, {'x' => [{'a' => ['b']}]}], JSI::JSON::Pointer.new([1, 'x', 0, 'a', 0])).node_content)
     end
   end
   describe '#deref' do
-    let(:document) do
+    let(:node_document) do
       {
         'foo' => {'bar' => ['baz']},
         'a' => {'$ref' => '#/foo'},
       }
     end
     it 'follows a $ref' do
-      assert_equal({'bar' => ['baz']}, node['a'].deref.content)
+      assert_equal({'bar' => ['baz']}, node['a'].deref.node_content)
     end
     it 'returns the node when there is no $ref to follow' do
-      assert_equal({'bar' => ['baz']}, node['foo'].deref.content)
+      assert_equal({'bar' => ['baz']}, node['foo'].deref.node_content)
     end
     describe "dealing with google's invalid $refs" do
-      let(:document) do
+      let(:node_document) do
         {
           'schemas' => {'bar' => {'description' => ['baz']}},
           'a' => {'$ref' => 'bar', 'foo' => 'bar'},
@@ -78,16 +73,16 @@ describe JSI::JSON::Node do
       end
       it 'subscripts a node consisting of a $ref WITHOUT following' do
         subscripted = node['a']
-        assert_equal({'$ref' => 'bar', 'foo' => 'bar'}, subscripted.content)
-        assert_equal(JSI::JSON::Pointer.new(['a']), subscripted.pointer)
+        assert_equal({'$ref' => 'bar', 'foo' => 'bar'}, subscripted.node_content)
+        assert_equal(JSI::JSON::Pointer.new(['a']), subscripted.node_ptr)
       end
       it 'looks for a node in #/schemas with the name of the $ref' do
-        assert_equal({'description' => ['baz']}, node['a'].deref.content)
+        assert_equal({'description' => ['baz']}, node['a'].deref.node_content)
       end
       it 'follows a $ref when subscripting past it' do
         subscripted = node['a']['description']
-        assert_equal(['baz'], subscripted.content)
-        assert_equal(JSI::JSON::Pointer.new(['schemas', 'bar', 'description']), subscripted.pointer)
+        assert_equal(['baz'], subscripted.node_content)
+        assert_equal(JSI::JSON::Pointer.new(['schemas', 'bar', 'description']), subscripted.node_ptr)
       end
       it 'does not follow a $ref when subscripting a key that is present' do
         subscripted = node['a']['foo']
@@ -96,45 +91,45 @@ describe JSI::JSON::Node do
     end
     describe "dealing with whatever this is" do
       # I think google uses this style in some cases maybe. I don't remember.
-      let(:document) do
+      let(:node_document) do
         {
           'schemas' => {'bar' => {'id' => 'BarID', 'description' => 'baz'}},
           'a' => {'$ref' => 'BarID'},
         }
       end
       it 'looks for a node in #/schemas with the name of the $ref' do
-        assert_equal({'id' => 'BarID', 'description' => 'baz'}, node['a'].deref.content)
+        assert_equal({'id' => 'BarID', 'description' => 'baz'}, node['a'].deref.node_content)
       end
     end
   end
   describe '#[]' do
     describe 'without dereferencing' do
-      let(:document) { [0, {'x' => [{'a' => ['b']}]}] }
+      let(:node_document) { [0, {'x' => [{'a' => ['b']}]}] }
       it 'subscripts arrays and hashes' do
         assert_equal('b', node[1]['x'][0]['a'][0])
       end
       it 'returns ArrayNode for an array' do
         subscripted = node[1]['x']
         assert_instance_of(JSI::JSON::ArrayNode, subscripted)
-        assert_equal([{'a' => ['b']}], subscripted.content)
-        assert_equal(JSI::JSON::Pointer.new([1, 'x']), subscripted.pointer)
+        assert_equal([{'a' => ['b']}], subscripted.node_content)
+        assert_equal(JSI::JSON::Pointer.new([1, 'x']), subscripted.node_ptr)
       end
       it 'returns HashNode for a Hash' do
         subscripted = node[1]
         assert_instance_of(JSI::JSON::HashNode, subscripted)
-        assert_equal({'x' => [{'a' => ['b']}]}, subscripted.content)
-        assert_equal(JSI::JSON::Pointer.new([1]), subscripted.pointer)
+        assert_equal({'x' => [{'a' => ['b']}]}, subscripted.node_content)
+        assert_equal(JSI::JSON::Pointer.new([1]), subscripted.node_ptr)
       end
-      describe 'content does not respond to []' do
-        let(:document) { Object.new }
+      describe 'node_content does not respond to []' do
+        let(:node_document) { Object.new }
         it 'cannot subscript' do
           err = assert_raises(NoMethodError) { node['x'] }
-          assert_equal("undefined method `[]`\nsubscripting with \"x\" (String) from Object. content is: #{document.pretty_inspect.chomp}", err.message)
+          assert_equal("undefined method `[]`\nsubscripting with \"x\" (String) from Object. content is: #{node_document.pretty_inspect.chomp}", err.message)
         end
       end
     end
     describe 'with dereferencing' do
-      let(:document) do
+      let(:node_document) do
         {
           'foo' => {'bar' => ['baz']},
           'a' => {'$ref' => '#/foo', 'description' => 'hi'}, # not sure a description is actually allowed here, whatever
@@ -142,13 +137,13 @@ describe JSI::JSON::Node do
       end
       it 'subscripts a node consisting of a $ref WITHOUT following' do
         subscripted = node['a']
-        assert_equal({'$ref' => '#/foo', 'description' => 'hi'}, subscripted.content)
-        assert_equal(JSI::JSON::Pointer.new(['a']), subscripted.pointer)
+        assert_equal({'$ref' => '#/foo', 'description' => 'hi'}, subscripted.node_content)
+        assert_equal(JSI::JSON::Pointer.new(['a']), subscripted.node_ptr)
       end
       it 'follows a $ref when subscripting past it' do
         subscripted = node['a']['bar']
-        assert_equal(['baz'], subscripted.content)
-        assert_equal(JSI::JSON::Pointer.new(['foo', 'bar']), subscripted.pointer)
+        assert_equal(['baz'], subscripted.node_content)
+        assert_equal(JSI::JSON::Pointer.new(['foo', 'bar']), subscripted.node_ptr)
       end
       it 'does not follow a $ref when subscripting a key that is present' do
         subscripted = node['a']['description']
@@ -157,39 +152,39 @@ describe JSI::JSON::Node do
     end
   end
   describe '#[]=' do
-    let(:document) { [0, {'x' => [{'a' => ['b']}]}] }
+    let(:node_document) { [0, {'x' => [{'a' => ['b']}]}] }
     it 'assigns' do
       node[0] = 'abcdefg'
-      assert_equal(['abcdefg', {'x' => [{'a' => ['b']}]}], document)
-      string_node = JSI::JSON::Node.new(document, JSI::JSON::Pointer.new([0]))
+      assert_equal(['abcdefg', {'x' => [{'a' => ['b']}]}], node_document)
+      string_node = JSI::JSON::Node.new(node_document, JSI::JSON::Pointer.new([0]))
       string_node[0..2] = '0'
-      assert_equal(['0defg', {'x' => [{'a' => ['b']}]}], document)
+      assert_equal(['0defg', {'x' => [{'a' => ['b']}]}], node_document)
       node[0] = node[1]
-      assert_equal([{'x' => [{'a' => ['b']}]}, {'x' => [{'a' => ['b']}]}], document)
+      assert_equal([{'x' => [{'a' => ['b']}]}, {'x' => [{'a' => ['b']}]}], node_document)
     end
     it 'assigns, deeper' do
       node[1]['y'] = node[1]['x'][0]
-      assert_equal([0, {'x' => [{'a' => ['b']}], 'y' => {'a' => ['b']}}], document)
+      assert_equal([0, {'x' => [{'a' => ['b']}], 'y' => {'a' => ['b']}}], node_document)
     end
   end
-  describe '#document_node' do
-    let(:document) { {'a' => {'b' => 3}} }
-    it 'has content that is the document' do
-      assert_equal({'a' => {'b' => 3}}, node['a'].document_node.content)
+  describe '#document_root_node' do
+    let(:node_document) { {'a' => {'b' => 3}} }
+    it 'has node_content that is the node_document' do
+      assert_equal({'a' => {'b' => 3}}, node['a'].document_root_node.node_content)
     end
   end
   describe '#parent_node' do
-    let(:document) { {'a' => {'b' => []}} }
+    let(:node_document) { {'a' => {'b' => []}} }
     it 'finds a parent' do
       sub = node['a']['b']
-      assert_equal(JSI::JSON::Pointer.new(['a', 'b']), sub.pointer)
+      assert_equal(JSI::JSON::Pointer.new(['a', 'b']), sub.node_ptr)
       parent = sub.parent_node
-      assert_equal(JSI::JSON::Pointer.new(['a']), parent.pointer)
-      assert_equal({'b' => []}, parent.content)
+      assert_equal(JSI::JSON::Pointer.new(['a']), parent.node_ptr)
+      assert_equal({'b' => []}, parent.node_content)
       assert_equal(node['a'], parent)
       root_from_sub = sub.parent_node.parent_node
-      assert_equal(JSI::JSON::Pointer.new([]), root_from_sub.pointer)
-      assert_equal({'a' => {'b' => []}}, root_from_sub.content)
+      assert_equal(JSI::JSON::Pointer.new([]), root_from_sub.node_ptr)
+      assert_equal({'a' => {'b' => []}}, root_from_sub.node_content)
       assert_equal(node, root_from_sub)
       err = assert_raises(JSI::JSON::Pointer::ReferenceError) do
         root_from_sub.parent_node
@@ -197,38 +192,8 @@ describe JSI::JSON::Node do
       assert_match(/\Acannot access parent of root pointer: #<JSI::JSON::Pointer/, err.message)
     end
   end
-  describe '#pointer_path' do
-    let(:document) { {'a' => {'b' => 3}} }
-    it 'is empty' do
-      assert_equal('', node.pointer_path)
-    end
-    it 'is not empty' do
-      assert_equal('/a', node['a'].pointer_path)
-    end
-    describe 'containing an empty string and some slashes and tildes that need escaping' do
-      let(:document) { {'' => {'a/b~c!d#e[f]' => []}} }
-      it 'matches' do
-        assert_equal('//a~1b~0c!d#e[f]', node['']['a/b~c!d#e[f]'].pointer_path)
-      end
-    end
-  end
-  describe '#fragment' do
-    let(:document) { {'a' => {'b' => 3}} }
-    it 'is empty' do
-      assert_equal('#', node.fragment)
-    end
-    it 'is not empty' do
-      assert_equal('#/a', node['a'].fragment)
-    end
-    describe 'containing an empty string and some slashes and tildes that need escaping' do
-      let(:document) { {'' => {'a/b~c!d#e[f]' => []}} }
-      it 'matches' do
-        assert_equal('#//a~1b~0c!d#e%5Bf%5D', node['']['a/b~c!d#e[f]'].fragment)
-      end
-    end
-  end
   describe '#modified_copy' do
-    let(:document) { [['b', 'q'], {'c' => ['d', 'e']}] }
+    let(:node_document) { [['b', 'q'], {'c' => ['d', 'e']}] }
     let(:path) { ['1', 'c'] }
     it 'returns a different object' do
       # simplest thing
@@ -238,10 +203,10 @@ describe JSI::JSON::Node do
       # but different object
       refute_equal(node.object_id, modified_dup.object_id)
       # the parents, obviously, are different
-      refute_equal(node.parent_node.content.object_id, modified_dup.parent_node.content.object_id)
-      refute_equal(node.parent_node.parent_node.content.object_id, modified_dup.parent_node.parent_node.content.object_id)
-      # but any untouched part(s) - in this case the ['b', 'q'] at document[0] - are untouched
-      assert_equal(node.document_node[0].content.object_id, modified_dup.document_node[0].content.object_id)
+      refute_equal(node.parent_node.node_content.object_id, modified_dup.parent_node.node_content.object_id)
+      refute_equal(node.parent_node.parent_node.node_content.object_id, modified_dup.parent_node.parent_node.node_content.object_id)
+      # but any untouched part(s) - in this case the ['b', 'q'] at node_document[0] - are untouched
+      assert_equal(node.document_root_node[0].node_content.object_id, modified_dup.document_root_node[0].node_content.object_id)
     end
     it 'returns the same object' do
       unmodified_dup = node.modified_copy { |o| o }
@@ -249,60 +214,60 @@ describe JSI::JSON::Node do
       # same object, since the block just returned it
       refute_equal(node.object_id, unmodified_dup.object_id)
       # the parents are unchanged since the object is the same
-      assert_equal(node.parent_node.content.object_id, unmodified_dup.parent_node.content.object_id)
-      assert_equal(node.parent_node.parent_node.content.object_id, unmodified_dup.parent_node.parent_node.content.object_id)
-      # same as the other: any untouched part(s) - in this case the ['b', 'q'] at document[0] - are untouched
-      assert_equal(node.document_node[0].content.object_id, unmodified_dup.document_node[0].content.object_id)
+      assert_equal(node.parent_node.node_content.object_id, unmodified_dup.parent_node.node_content.object_id)
+      assert_equal(node.parent_node.parent_node.node_content.object_id, unmodified_dup.parent_node.parent_node.node_content.object_id)
+      # same as the other: any untouched part(s) - in this case the ['b', 'q'] at node_document[0] - are untouched
+      assert_equal(node.document_root_node[0].node_content.object_id, unmodified_dup.document_root_node[0].node_content.object_id)
     end
     it 'raises subscripting string from array' do
-      err = assert_raises(TypeError) { JSI::JSON::Node.new(document, JSI::JSON::Pointer.new(['x'])).modified_copy(&:dup) }
+      err = assert_raises(TypeError) { JSI::JSON::Node.new(node_document, JSI::JSON::Pointer.new(['x'])).modified_copy(&:dup) }
       assert_match(%r(\Abad subscript "x" with remaining subpath: \[\] for array: \[.*\]\z)m, err.message)
     end
     it 'raises subscripting from invalid subpath' do
-      err = assert_raises(TypeError) { JSI::JSON::Node.new(document, JSI::JSON::Pointer.new([0, 0, 'what'])).modified_copy(&:dup) }
+      err = assert_raises(TypeError) { JSI::JSON::Node.new(node_document, JSI::JSON::Pointer.new([0, 0, 'what'])).modified_copy(&:dup) }
       assert_match(%r(bad subscript: "what" with remaining subpath: \[\] for content: "b"\z)m, err.message)
     end
   end
   describe '#inspect' do
-    let(:document) { {'a' => {'c' => ['d', 'e']}} }
+    let(:node_document) { {'a' => {'c' => ['d', 'e']}} }
     let(:path) { ['a'] }
     it 'inspects' do
       assert_equal(%Q(#<JSI::JSON::Node fragment="#/a" {"c"=>["d", "e"]}>), node.inspect)
     end
   end
   describe '#pretty_print' do
-    let(:document) { {'a' => {'c' => ['d', 'e']}} }
+    let(:node_document) { {'a' => {'c' => ['d', 'e']}} }
     let(:path) { ['a'] }
     it 'pretty prints' do
       assert_equal(%Q(#<JSI::JSON::Node fragment="#/a" {"c"=>["d", "e"]}>), node.pretty_inspect.chomp)
     end
   end
   describe '#fingerprint' do
-    let(:pointer) { JSI::JSON::Pointer.new([]) }
+    let(:node_ptr) { JSI::JSON::Pointer.new([]) }
     it 'hashes consistently' do
-      assert_equal('x', {JSI::JSON::Node.new([0], pointer) => 'x'}[JSI::JSON::Node.new([0], pointer)])
+      assert_equal('x', {JSI::JSON::Node.new([0], node_ptr) => 'x'}[JSI::JSON::Node.new([0], node_ptr)])
     end
     it 'hashes consistently regardless of the Node being decorated as a subclass' do
-      assert_equal('x', {JSI::JSON::Node.new_doc([0]) => 'x'}[JSI::JSON::Node.new([0], pointer)])
-      assert_equal('x', {JSI::JSON::Node.new([0], pointer) => 'x'}[JSI::JSON::Node.new_doc([0])])
+      assert_equal('x', {JSI::JSON::Node.new_doc([0]) => 'x'}[JSI::JSON::Node.new([0], node_ptr)])
+      assert_equal('x', {JSI::JSON::Node.new([0], node_ptr) => 'x'}[JSI::JSON::Node.new_doc([0])])
     end
     it '==' do
-      assert_equal(JSI::JSON::Node.new([0], pointer), JSI::JSON::Node.new([0], pointer))
-      assert_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new([0], pointer))
-      assert_equal(JSI::JSON::Node.new([0], pointer), JSI::JSON::Node.new_doc([0]))
+      assert_equal(JSI::JSON::Node.new([0], node_ptr), JSI::JSON::Node.new([0], node_ptr))
+      assert_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new([0], node_ptr))
+      assert_equal(JSI::JSON::Node.new([0], node_ptr), JSI::JSON::Node.new_doc([0]))
       assert_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new_doc([0]))
     end
     it '!=' do
-      refute_equal(JSI::JSON::Node.new([0], pointer), JSI::JSON::Node.new({}, pointer))
-      refute_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new({}, pointer))
-      refute_equal(JSI::JSON::Node.new([0], pointer), JSI::JSON::Node.new_doc({}))
+      refute_equal(JSI::JSON::Node.new([0], node_ptr), JSI::JSON::Node.new({}, node_ptr))
+      refute_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new({}, node_ptr))
+      refute_equal(JSI::JSON::Node.new([0], node_ptr), JSI::JSON::Node.new_doc({}))
       refute_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new_doc({}))
       refute_equal({}, JSI::JSON::Node.new_doc({}))
       refute_equal(JSI::JSON::Node.new_doc({}), {})
     end
   end
   describe '#as_json' do
-    let(:document) { {'a' => 'b'} }
+    let(:node_document) { {'a' => 'b'} }
     it '#as_json' do
       assert_equal({'a' => 'b'}, node.as_json)
     end


### PR DESCRIPTION
simplify JSI::JSON::Node. unify naming to the names used by PathedNode. drop methods I don't wish to be API.