### PR TITLE
remove implicit deref from JSI::Base#[] and Node#[]

### DIFF
--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -243,12 +243,6 @@ module JSI
         raise(NoMethodError, "cannot subcript (using token: #{token.inspect}) from instance: #{jsi_instance.pretty_inspect.chomp}")
       end
 
-      if !token_is_ours_
-        deref do |deref_jsi|
-          return deref_jsi[token]
-        end
-      end
-
       memoize(:[], token, value_, token_is_ours_) do |token_, value, token_is_ours|
         if respond_to?(:to_ary)
           token_schema = schema.subschema_for_index(token_)

--- a/lib/jsi/json/node.rb
+++ b/lib/jsi/json/node.rb
@@ -74,11 +74,6 @@ module JSI
       def [](subscript)
         ptr = self.node_ptr
         content = self.node_content
-        if content.respond_to?(:to_hash) && !(content.respond_to?(:key?) ? content : content.to_hash).key?(subscript)
-          deref do |deref_node|
-            return deref_node[subscript]
-          end
-        end
         unless content.respond_to?(:[])
           if content.respond_to?(:to_hash)
             content = content.to_hash

--- a/test/jsi_json_node_test.rb
+++ b/test/jsi_json_node_test.rb
@@ -79,15 +79,6 @@ describe JSI::JSON::Node do
       it 'looks for a node in #/schemas with the name of the $ref' do
         assert_equal({'description' => ['baz']}, node['a'].deref.node_content)
       end
-      it 'follows a $ref when subscripting past it' do
-        subscripted = node['a']['description']
-        assert_equal(['baz'], subscripted.node_content)
-        assert_equal(JSI::JSON::Pointer.new(['schemas', 'bar', 'description']), subscripted.node_ptr)
-      end
-      it 'does not follow a $ref when subscripting a key that is present' do
-        subscripted = node['a']['foo']
-        assert_equal('bar', subscripted)
-      end
     end
     describe "dealing with whatever this is" do
       # I think google uses this style in some cases maybe. I don't remember.
@@ -135,19 +126,10 @@ describe JSI::JSON::Node do
           'a' => {'$ref' => '#/foo', 'description' => 'hi'}, # not sure a description is actually allowed here, whatever
         }
       end
-      it 'subscripts a node consisting of a $ref WITHOUT following' do
+      it 'subscripts a node consisting of a $ref without following' do
         subscripted = node['a']
         assert_equal({'$ref' => '#/foo', 'description' => 'hi'}, subscripted.node_content)
         assert_equal(JSI::JSON::Pointer.new(['a']), subscripted.node_ptr)
-      end
-      it 'follows a $ref when subscripting past it' do
-        subscripted = node['a']['bar']
-        assert_equal(['baz'], subscripted.node_content)
-        assert_equal(JSI::JSON::Pointer.new(['foo', 'bar']), subscripted.node_ptr)
-      end
-      it 'does not follow a $ref when subscripting a key that is present' do
-        subscripted = node['a']['description']
-        assert_equal('hi', subscripted)
       end
     end
   end


### PR DESCRIPTION
this was a hack for OpenAPI's Reference / JsonReference, but we don't need it now, and it was quite incorrect to apply universally