### PR TITLE
JSI schema accessor module

### DIFF
--- a/lib/jsi/metaschema_node.rb
+++ b/lib/jsi/metaschema_node.rb
@@ -81,7 +81,7 @@ module JSI
       end
 
       if @schema
-        extend(JSI::SchemaClasses.module_for_schema(@schema, conflicting_modules: [Metaschema, Schema, MetaschemaNode, PathedArrayNode, PathedHashNode]))
+        extend(JSI::SchemaClasses.accessor_module_for_schema(@schema, conflicting_modules: [Metaschema, Schema, MetaschemaNode, PathedArrayNode, PathedHashNode]))
       end
 
       # workarounds

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -125,12 +125,9 @@ module JSI
       end
     end
 
-    # @param conflicting_modules [Enumerable<Module>] an array of modules (or classes) which
-    #   may be used alongside the schema module. methods defined by any conflicting_module
-    #   will not be defined as accessors for the JSI schema module.
     # @return [Module] a module representing this schema. see {JSI::SchemaClasses.module_for_schema}.
-    def jsi_schema_module(conflicting_modules: [Base, BaseArray, BaseHash])
-      JSI::SchemaClasses.module_for_schema(self, conflicting_modules: conflicting_modules)
+    def jsi_schema_module
+      JSI::SchemaClasses.module_for_schema(self)
     end
 
     # @return [Class subclassing JSI::Base] shortcut for JSI.class_for_schema(schema)

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -322,8 +322,7 @@ describe JSI::Base do
           }
         end
         it 'does not define readers' do
-          assert_equal('bar', subject.foo)
-          assert_equal(JSI::SchemaClasses.module_for_schema(subject.schema, conflicting_modules: [JSI::Base, JSI::BaseArray, JSI::BaseHash]), subject.method(:foo).owner)
+          assert_equal('bar', subject.foo) # this one is defined
 
           assert_equal(JSI::Base, subject.method(:initialize).owner)
           assert_equal('hi', subject['initialize'])


### PR DESCRIPTION
move accessor methods to a separate module which becomes included in the primary JSI schema module

this lets overridden accessor methods call #super