### PR TITLE
JSI schema module over class

### DIFF
--- a/lib/schemas/json-schema.org/draft-04/schema.rb
+++ b/lib/schemas/json-schema.org/draft-04/schema.rb
@@ -4,5 +4,5 @@ module JSI
   schema_id = 'http://json-schema.org/draft-04/schema'
   schema_content = ::JSON.parse(File.read(::JSON::Validator.validators[schema_id].metaschema))
   JSONSchemaOrgDraft04Schema = MetaschemaNode.new(schema_content)
-  JSONSchemaOrgDraft04 = JSONSchemaOrgDraft04Schema.jsi_schema_class
+  JSONSchemaOrgDraft04 = JSONSchemaOrgDraft04Schema.jsi_schema_module
 end

--- a/lib/schemas/json-schema.org/draft-06/schema.rb
+++ b/lib/schemas/json-schema.org/draft-06/schema.rb
@@ -4,5 +4,5 @@ module JSI
   schema_id = 'http://json-schema.org/draft/schema' # I don't know why this is not http://json-schema.org/draft-06/schema
   schema_content = ::JSON.parse(File.read(::JSON::Validator.validators[schema_id].metaschema))
   JSONSchemaOrgDraft06Schema = MetaschemaNode.new(schema_content)
-  JSONSchemaOrgDraft06 = JSONSchemaOrgDraft06Schema.jsi_schema_class
+  JSONSchemaOrgDraft06 = JSONSchemaOrgDraft06Schema.jsi_schema_module
 end

--- a/test/base_array_test.rb
+++ b/test/base_array_test.rb
@@ -50,7 +50,7 @@ describe JSI::BaseArray do
     describe 'nondefault value (nonbasic type)' do
       let(:instance) { [[2]] }
       it 'returns the nondefault value' do
-        assert_instance_of(JSI.class_for_schema(schema['items']), subject[0])
+        assert_is_a(schema.items.jsi_schema_module, subject[0])
         assert_equal([2], subject[0].as_json)
       end
     end
@@ -65,7 +65,7 @@ describe JSI::BaseArray do
     describe 'default value' do
       let(:instance) { [{'bar' => 3}] }
       it 'returns the default value' do
-        assert_instance_of(JSI.class_for_schema(schema['items']), subject[1])
+        assert_is_a(schema.items.jsi_schema_module, subject[1])
         assert_equal({'foo' => 2}, subject[1].as_json)
       end
     end
@@ -78,7 +78,7 @@ describe JSI::BaseArray do
     describe 'nondefault value (nonbasic type)' do
       let(:instance) { [true, [2]] }
       it 'returns the nondefault value' do
-        assert_instance_of(JSI.class_for_schema(schema['items']), subject[1])
+        assert_is_a(schema.items.jsi_schema_module, subject[1])
         assert_equal([2], subject[1].as_json)
       end
     end
@@ -90,8 +90,8 @@ describe JSI::BaseArray do
       subject[2] = {'y' => 'z'}
 
       assert_equal({'y' => 'z'}, subject[2].as_json)
-      assert_instance_of(JSI.class_for_schema(schema['items'][2]), orig_2)
-      assert_instance_of(JSI.class_for_schema(schema['items'][2]), subject[2])
+      assert_is_a(schema.items[2].jsi_schema_module, orig_2)
+      assert_is_a(schema.items[2].jsi_schema_module, subject[2])
     end
     it 'modifies the instance, visible to other references to the same instance' do
       orig_instance = subject.jsi_instance

--- a/test/base_hash_test.rb
+++ b/test/base_hash_test.rb
@@ -50,7 +50,7 @@ describe JSI::BaseHash do
     describe 'nondefault value (nonbasic type)' do
       let(:instance) { {'foo' => [2]} }
       it 'returns the nondefault value' do
-        assert_instance_of(JSI.class_for_schema(schema['properties']['foo']), subject.foo)
+        assert_is_a(schema.properties['foo'].jsi_schema_module, subject.foo)
         assert_equal([2], subject.foo.as_json)
       end
     end
@@ -67,7 +67,7 @@ describe JSI::BaseHash do
     describe 'default value' do
       let(:instance) { {'bar' => 3} }
       it 'returns the default value' do
-        assert_instance_of(JSI.class_for_schema(schema['properties']['foo']), subject.foo)
+        assert_is_a(schema.properties['foo'].jsi_schema_module, subject.foo)
         assert_equal({'foo' => 2}, subject.foo.as_json)
       end
     end
@@ -80,7 +80,7 @@ describe JSI::BaseHash do
     describe 'nondefault value (nonbasic type)' do
       let(:instance) { {'foo' => [2]} }
       it 'returns the nondefault value' do
-        assert_instance_of(JSI.class_for_schema(schema['properties']['foo']), subject.foo)
+        assert_is_a(schema.properties['foo'].jsi_schema_module, subject.foo)
         assert_equal([2], subject.foo.as_json)
       end
     end
@@ -92,8 +92,8 @@ describe JSI::BaseHash do
       subject['foo'] = {'y' => 'z'}
 
       assert_equal({'y' => 'z'}, subject['foo'].as_json)
-      assert_instance_of(JSI.class_for_schema(schema['properties']['foo']), orig_foo)
-      assert_instance_of(JSI.class_for_schema(schema['properties']['foo']), subject['foo'])
+      assert_is_a(schema.properties['foo'].jsi_schema_module, orig_foo)
+      assert_is_a(schema.properties['foo'].jsi_schema_module, subject['foo'])
     end
     it 'sets a property to a schema instance with a different schema' do
       assert(subject['foo'])
@@ -103,8 +103,8 @@ describe JSI::BaseHash do
       # the content of the subscripts' instances is the same but the subscripts' classes are different
       assert_equal([9], subject['foo'].as_json)
       assert_equal([9], subject['bar'].as_json)
-      assert_instance_of(JSI.class_for_schema(schema['properties']['foo']), subject['foo'])
-      assert_instance_of(JSI.class_for_schema(schema['properties']['bar']), subject['bar'])
+      assert_is_a(schema.properties['foo'].jsi_schema_module, subject['foo'])
+      assert_is_a(schema.properties['bar'].jsi_schema_module, subject['bar'])
     end
     it 'sets a property to a schema instance with the same schema' do
       other_subject = schema.new_jsi({'foo' => {'x' => 'y'}, 'bar' => [9], 'baz' => [true]})

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -153,7 +153,7 @@ describe JSI::Base do
       let(:instance) { JSI::Schema.new({}) }
       it 'initializes with an error' do
         err = assert_raises(TypeError) { subject }
-        assert_equal("assigning a schema to a (JSI Schema Class: #) instance is incorrect. received: \#{<JSI::JSONSchemaOrgDraft06 Schema>}", err.message)
+        assert_equal("assigning a schema to a (JSI Schema Class: #) instance is incorrect. received: \#{<JSI (JSI::JSONSchemaOrgDraft06) Schema>}", err.message)
       end
     end
   end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -272,11 +272,11 @@ describe JSI::Base do
     describe 'readers' do
       it 'reads attributes described as properties' do
         assert_equal({'x' => 'y'}, subject.foo.as_json)
-        assert_instance_of(JSI.class_for_schema(schema['properties']['foo']), subject.foo)
+        assert_is_a(schema.properties['foo'].jsi_schema_module, subject.foo)
         assert_respond_to(subject.foo, :to_hash)
         refute_respond_to(subject.foo, :to_ary)
         assert_equal([3.14159], subject.bar.as_json)
-        assert_instance_of(JSI.class_for_schema(schema['properties']['bar']), subject.bar)
+        assert_is_a(schema.properties['bar'].jsi_schema_module, subject.bar)
         refute_respond_to(subject.bar, :to_hash)
         assert_respond_to(subject.bar, :to_ary)
         assert_equal(true, subject.baz)
@@ -345,8 +345,8 @@ describe JSI::Base do
         subject.foo = {'y' => 'z'}
 
         assert_equal({'y' => 'z'}, subject.foo.as_json)
-        assert_instance_of(JSI.class_for_schema(schema['properties']['foo']), orig_foo)
-        assert_instance_of(JSI.class_for_schema(schema['properties']['foo']), subject.foo)
+        assert_is_a(schema.properties['foo'].jsi_schema_module, orig_foo)
+        assert_is_a(schema.properties['foo'].jsi_schema_module, subject.foo)
       end
       it 'modifies the instance, visible to other references to the same instance' do
         orig_instance = subject.jsi_instance

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -21,12 +21,12 @@ describe JSI::Schema do
     end
   end
   describe 'as an instance of metaschema' do
-    let(:metaschema_jsi_class) { JSI::JSONSchemaOrgDraft04 }
+    let(:metaschema_jsi_module) { JSI::JSONSchemaOrgDraft04 }
     let(:schema_object) { {'type' => 'array', 'items' => {'description' => 'items!'}} }
-    let(:schema) { metaschema_jsi_class.new(schema_object) }
+    let(:schema) { metaschema_jsi_module.new_jsi(schema_object) }
     it '#[]' do
       schema_items = schema['items']
-      assert_instance_of(metaschema_jsi_class, schema_items)
+      assert_is_a(metaschema_jsi_module, schema_items)
       assert_equal({'description' => 'items!'}, schema_items.as_json)
     end
   end
@@ -144,10 +144,10 @@ describe JSI::Schema do
     end
 
     it '#inspect' do
-      assert_equal("\#{<JSI::JSONSchemaOrgDraft06 Schema> \"id\" => \"https://schemas.jsi.unth.net/test/stringification\", \"type\" => \"object\"}", schema.inspect)
+      assert_equal("\#{<JSI (JSI::JSONSchemaOrgDraft06) Schema> \"id\" => \"https://schemas.jsi.unth.net/test/stringification\", \"type\" => \"object\"}", schema.inspect)
     end
     it '#pretty_print' do
-      assert_equal("\#{<JSI::JSONSchemaOrgDraft06 Schema>
+      assert_equal("\#{<JSI (JSI::JSONSchemaOrgDraft06) Schema>
         \"id\" => \"https://schemas.jsi.unth.net/test/stringification\",
         \"type\" => \"object\"
       }".gsub(/^      /, ''), schema.pretty_inspect.chomp)

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -85,17 +85,17 @@ describe JSI::Schema do
     end
     it 'has a subschema by property' do
       subschema = schema.subschema_for_property('foo')
-      assert_instance_of(JSI::Schema.default_metaschema.jsi_schema_class, subschema)
+      assert_is_a(JSI::Schema.default_metaschema.jsi_schema_module, subschema)
       assert_equal('foo', subschema['description'])
     end
     it 'has a subschema by pattern property' do
       subschema = schema.subschema_for_property('bar')
-      assert_instance_of(JSI::Schema.default_metaschema.jsi_schema_class, subschema)
+      assert_is_a(JSI::Schema.default_metaschema.jsi_schema_module, subschema)
       assert_equal('ba*', subschema['description'])
     end
     it 'has a subschema by additional properties' do
       subschema = schema.subschema_for_property('anything')
-      assert_instance_of(JSI::Schema.default_metaschema.jsi_schema_class, subschema)
+      assert_is_a(JSI::Schema.default_metaschema.jsi_schema_module, subschema)
       assert_equal('whatever', subschema['description'])
     end
   end
@@ -108,10 +108,10 @@ describe JSI::Schema do
         items: {description: 'items!'}
       })
       first_subschema = schema.subschema_for_index(0)
-      assert_instance_of(JSI::Schema.default_metaschema.jsi_schema_class, first_subschema)
+      assert_is_a(JSI::Schema.default_metaschema.jsi_schema_module, first_subschema)
       assert_equal('items!', first_subschema['description'])
       last_subschema = schema.subschema_for_index(1)
-      assert_instance_of(JSI::Schema.default_metaschema.jsi_schema_class, last_subschema)
+      assert_is_a(JSI::Schema.default_metaschema.jsi_schema_module, last_subschema)
       assert_equal('items!', last_subschema['description'])
     end
     it 'has a subschema for each item by index' do
@@ -119,10 +119,10 @@ describe JSI::Schema do
         items: [{description: 'item one'}, {description: 'item two'}]
       })
       first_subschema = schema.subschema_for_index(0)
-      assert_instance_of(JSI::Schema.default_metaschema.jsi_schema_class, first_subschema)
+      assert_is_a(JSI::Schema.default_metaschema.jsi_schema_module, first_subschema)
       assert_equal('item one', first_subschema['description'])
       last_subschema = schema.subschema_for_index(1)
-      assert_instance_of(JSI::Schema.default_metaschema.jsi_schema_class, last_subschema)
+      assert_is_a(JSI::Schema.default_metaschema.jsi_schema_module, last_subschema)
       assert_equal('item two', last_subschema['description'])
     end
     it 'has a subschema by additional items' do
@@ -131,10 +131,10 @@ describe JSI::Schema do
         additionalItems: {description: "mo' crap"},
       })
       first_subschema = schema.subschema_for_index(0)
-      assert_instance_of(JSI::Schema.default_metaschema.jsi_schema_class, first_subschema)
+      assert_is_a(JSI::Schema.default_metaschema.jsi_schema_module, first_subschema)
       assert_equal('item one', first_subschema['description'])
       last_subschema = schema.subschema_for_index(1)
-      assert_instance_of(JSI::Schema.default_metaschema.jsi_schema_class, last_subschema)
+      assert_is_a(JSI::Schema.default_metaschema.jsi_schema_module, last_subschema)
       assert_equal("mo' crap", last_subschema['description'])
     end
   end


### PR DESCRIPTION
moving away from a class for a schema and toward a module for a schema.
the drafts (`JSI::JSONSchemaOrgDraft06` etc) will be modules instead of classes.
tests prefer to check instantiation of schema module to schema class.