### PR TITLE
Let callers pass arguments to fully_validate

### DIFF
--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -348,8 +348,8 @@ module JSI
     end
 
     # @return [Array<String>] array of schema validation error messages for this instance
-    def fully_validate
-      schema.fully_validate_instance(jsi_instance)
+    def fully_validate **args
+      schema.fully_validate_instance(jsi_instance, args)
     end
 
     # @return [true, false] whether the instance validates against its schema

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -226,8 +226,8 @@ module JSI
 
     # @return [Array<String>] array of schema validation error messages for
     #   the given instance against this schema
-    def fully_validate_instance(other_instance)
-      ::JSON::Validator.fully_validate(JSI::Typelike.as_json(node_document), JSI::Typelike.as_json(other_instance), fragment: node_ptr.fragment)
+    def fully_validate_instance(other_instance, **args)
+      ::JSON::Validator.fully_validate(JSI::Typelike.as_json(node_document), JSI::Typelike.as_json(other_instance), args)
     end
 
     # @return [true, false] whether the given instance validates against this schema

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -11,6 +11,24 @@ describe JSI::Base do
   let(:schema) { JSI::Schema.new(schema_content) }
   let(:instance) { {} }
   let(:subject) { schema.new_jsi(instance) }
+
+  let(:schema_content_for_errors) {
+    {
+      'type' => 'object',
+      'properties' => {
+        'some_number' => {
+          'type' => 'number'
+        },
+        'a_required_property' => {
+          'type' => 'string'
+        }
+      }
+    }
+  }
+  let(:schema_for_errors) { JSI::Schema.new(schema_content_for_errors) }
+  let(:instance_for_errors) { "this is a string" }
+  let(:subject_for_errors) { schema_for_errors.new_jsi(instance_for_errors) }
+
   describe 'class .inspect' do
     it 'is the same as Class#inspect on the base' do
       assert_equal('JSI::Base', JSI::Base.inspect)
@@ -252,6 +270,25 @@ describe JSI::Base do
       end
       it '#validate!' do
         assert_equal(true, subject.validate!)
+      end
+    end
+    describe 'with errors' do
+      it '#validate' do
+        assert_equal(false, subject_for_errors.validate)
+      end
+      it '#validate!' do
+        assert_raises JSON::Schema::ValidationError do
+          subject_for_errors.validate!
+        end
+      end
+      describe 'fully_validate' do
+        it '#fully_validate ' do
+          assert_equal(String, subject_for_errors.fully_validate[0].class)
+        end
+        it '#fully_validate :errors_as_objects' do
+          response = subject_for_errors.fully_validate(:errors_as_objects => true)
+          assert_equal(Hash, response[0].class)
+        end
       end
     end
   end


### PR DESCRIPTION
`fully_validate` currently returns all errors as an array of strings. Those strings aren't particularly readable. `json-schema` does let you as for the errors in object format, `:errors_as_objects => true`.

This PR basically lets users pass the keyword arguments down from JSI to json-schema. It also adds a tests for validation *with errors*.