### PR TITLE
remove constants which refer to metaschema instances

### DIFF
--- a/lib/jsi.rb
+++ b/lib/jsi.rb
@@ -30,10 +30,9 @@ module JSI
   autoload :SchemaClasses, 'jsi/schema_classes'
   autoload :JSICoder, 'jsi/jsi_coder'
 
-  autoload :JSONSchemaOrgDraft04Schema, 'schemas/json-schema.org/draft-04/schema'
-  autoload :JSONSchemaOrgDraft04,       'schemas/json-schema.org/draft-04/schema'
-  autoload :JSONSchemaOrgDraft06Schema, 'schemas/json-schema.org/draft-06/schema'
-  autoload :JSONSchemaOrgDraft06,       'schemas/json-schema.org/draft-06/schema'
+  autoload :JSONSchemaOrgDraft04, 'schemas/json-schema.org/draft-04/schema'
+  autoload :JSONSchemaOrgDraft06, 'schemas/json-schema.org/draft-06/schema'
+
   autoload :SimpleWrap, 'jsi/simple_wrap'
 
   # @return [Class subclassing JSI::Base] a JSI class which represents the

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -26,14 +26,14 @@ module JSI
     class << self
       # @return [JSI::Schema] the default metaschema
       def default_metaschema
-        JSI::JSONSchemaOrgDraft06Schema
+        JSI::JSONSchemaOrgDraft06.schema
       end
 
       # @return [Array<JSI::Schema>] supported metaschemas
       def supported_metaschemas
         [
-          JSI::JSONSchemaOrgDraft04Schema,
-          JSI::JSONSchemaOrgDraft06Schema,
+          JSI::JSONSchemaOrgDraft04.schema,
+          JSI::JSONSchemaOrgDraft06.schema,
         ]
       end
 

--- a/lib/schemas/json-schema.org/draft-04/schema.rb
+++ b/lib/schemas/json-schema.org/draft-04/schema.rb
@@ -3,6 +3,5 @@
 module JSI
   schema_id = 'http://json-schema.org/draft-04/schema'
   schema_content = ::JSON.parse(File.read(::JSON::Validator.validators[schema_id].metaschema))
-  JSONSchemaOrgDraft04Schema = MetaschemaNode.new(schema_content)
-  JSONSchemaOrgDraft04 = JSONSchemaOrgDraft04Schema.jsi_schema_module
+  JSONSchemaOrgDraft04 = MetaschemaNode.new(schema_content).jsi_schema_module
 end

--- a/lib/schemas/json-schema.org/draft-06/schema.rb
+++ b/lib/schemas/json-schema.org/draft-06/schema.rb
@@ -3,6 +3,5 @@
 module JSI
   schema_id = 'http://json-schema.org/draft/schema' # I don't know why this is not http://json-schema.org/draft-06/schema
   schema_content = ::JSON.parse(File.read(::JSON::Validator.validators[schema_id].metaschema))
-  JSONSchemaOrgDraft06Schema = MetaschemaNode.new(schema_content)
-  JSONSchemaOrgDraft06 = JSONSchemaOrgDraft06Schema.jsi_schema_module
+  JSONSchemaOrgDraft06 = MetaschemaNode.new(schema_content).jsi_schema_module
 end

--- a/test/metaschema_node_test.rb
+++ b/test/metaschema_node_test.rb
@@ -13,7 +13,7 @@ describe JSI::MetaschemaNode do
   end
   describe 'json schema draft' do
     it 'type has a schema' do
-      assert(JSI::JSONSchemaOrgDraft06Schema.type.schema)
+      assert(JSI::JSONSchemaOrgDraft06.schema.type.schema)
     end
   end
 end


### PR DESCRIPTION
 just use the schema modules and their .schema method