### PR TITLE
names and prefixes

### DIFF
--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -47,7 +47,7 @@ module JSI
             elsif schema.schema_id
               schema.schema_id
             else
-              schema.node_ptr.uri
+              schema.jsi_ptr.uri
             end
           end
 
@@ -183,8 +183,6 @@ module JSI
     # the JSI at the root of this JSI's document
     attr_reader :jsi_root_node
 
-    alias_method :node_document, :jsi_document
-    alias_method :node_ptr, :jsi_ptr
     alias_method :document_root_node, :jsi_root_node
 
     # the instance of the json-schema - the underlying JSON data used to instantiate this JSI
@@ -309,7 +307,7 @@ module JSI
     #   (e.g. a $ref to an external document, which is not yet supported), the block is not called.
     # @return [JSI::Base, self]
     def deref(&block)
-      node_ptr_deref do |deref_ptr|
+      jsi_ptr_deref do |deref_ptr|
         deref_ptr.evaluate(jsi_root_node).tap(&(block || Util::NOOP))
       end
       return self
@@ -323,7 +321,7 @@ module JSI
     #   in a (nondestructively) modified copy of this.
     # @return [JSI::Base subclass the same as self] the modified copy of self
     def modified_copy(&block)
-      if node_ptr.root?
+      if jsi_ptr.root?
         modified_document = @jsi_ptr.modified_document_copy(@jsi_document, &block)
         self.class.new(Base::NOINSTANCE,
           jsi_document: modified_document,
@@ -333,7 +331,7 @@ module JSI
         modified_jsi_root_node = @jsi_root_node.modified_copy do |root|
           @jsi_ptr.modified_document_copy(root, &block)
         end
-        self.class.new(Base::NOINSTANCE, jsi_document: modified_jsi_root_node.node_document, jsi_ptr: @jsi_ptr, jsi_root_node: modified_jsi_root_node)
+        self.class.new(Base::NOINSTANCE, jsi_document: modified_jsi_root_node.jsi_document, jsi_ptr: @jsi_ptr, jsi_root_node: modified_jsi_root_node)
       end
     end
 

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -195,7 +195,7 @@ module JSI
     # an array of JSI instances above this one in the document.
     #
     # @return [Array<JSI::Base>]
-    def parent_jsis
+    def jsi_parent_nodes
       parent = jsi_root_node
 
       jsi_ptr.reference_tokens.map do |token|
@@ -208,16 +208,9 @@ module JSI
     # the immediate parent of this JSI. nil if there is no parent.
     #
     # @return [JSI::Base, nil]
-    def parent_jsi
-      parent_jsis.first
+    def jsi_parent_node
+      jsi_parent_nodes.first
     end
-
-    alias_method :parent_node, :parent_jsi
-
-    # @deprecated
-    alias_method :parents, :parent_jsis
-    # @deprecated
-    alias_method :parent, :parent_jsi
 
     # @param token [String, Integer, Object] the token to subscript
     # @return [JSI::Base, Object] the instance's subscript value at the given token.

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -184,7 +184,7 @@ module JSI
     attr_reader :jsi_root_node
 
     # the instance of the json-schema - the underlying JSON data used to instantiate this JSI
-    alias_method :jsi_instance, :node_content
+    alias_method :jsi_instance, :jsi_node_content
 
     # each is overridden by PathedHashNode or PathedArrayNode when appropriate. the base
     # #each is not actually implemented, along with all the methods of Enumerable.
@@ -219,11 +219,11 @@ module JSI
     #   value is returned.
     def [](token)
       if respond_to?(:to_hash)
-        token_in_range = node_content_hash_pubsend(:key?, token)
-        value = node_content_hash_pubsend(:[], token)
+        token_in_range = jsi_node_content_hash_pubsend(:key?, token)
+        value = jsi_node_content_hash_pubsend(:[], token)
       elsif respond_to?(:to_ary)
-        token_in_range = node_content_ary_pubsend(:each_index).include?(token)
-        value = node_content_ary_pubsend(:[], token)
+        token_in_range = jsi_node_content_ary_pubsend(:each_index).include?(token)
+        value = jsi_node_content_ary_pubsend(:[], token)
       else
         raise(CannotSubscriptError, "cannot subcript (using token: #{token.inspect}) from instance: #{jsi_instance.pretty_inspect.chomp}")
       end
@@ -392,20 +392,20 @@ module JSI
         end
       end
 
-      if (is_a?(PathedArrayNode) || is_a?(PathedHashNode)) && ![Array, Hash].include?(node_content.class)
-        if node_content.respond_to?(:object_group_text)
-          node_content_txt = node_content.object_group_text
+      if (is_a?(PathedArrayNode) || is_a?(PathedHashNode)) && ![Array, Hash].include?(jsi_node_content.class)
+        if jsi_node_content.respond_to?(:object_group_text)
+          content_txt = jsi_node_content.object_group_text
         else
-          node_content_txt = [node_content.class.to_s]
+          content_txt = [jsi_node_content.class.to_s]
         end
       else
-        node_content_txt = []
+        content_txt = []
       end
 
       [
         class_txt,
         is_a?(Metaschema) ? "Metaschema" : is_a?(Schema) ? "Schema" : nil,
-        *node_content_txt,
+        *content_txt,
       ].compact
     end
 

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -183,8 +183,6 @@ module JSI
     # the JSI at the root of this JSI's document
     attr_reader :jsi_root_node
 
-    alias_method :document_root_node, :jsi_root_node
-
     # the instance of the json-schema - the underlying JSON data used to instantiate this JSI
     alias_method :jsi_instance, :node_content
 

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -189,7 +189,6 @@ module JSI
 
     # the instance of the json-schema - the underlying JSON data used to instantiate this JSI
     alias_method :jsi_instance, :node_content
-    alias_method :instance, :node_content
 
     # each is overridden by PathedHashNode or PathedArrayNode when appropriate. the base
     # #each is not actually implemented, along with all the methods of Enumerable.

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -311,7 +311,7 @@ module JSI
     # @yield [Object] the content of the instance. the block should result
     #   in a (nondestructively) modified copy of this.
     # @return [JSI::Base subclass the same as self] the modified copy of self
-    def modified_copy(&block)
+    def jsi_modified_copy(&block)
       if jsi_ptr.root?
         modified_document = @jsi_ptr.modified_document_copy(@jsi_document, &block)
         self.class.new(Base::NOINSTANCE,
@@ -319,7 +319,7 @@ module JSI
           jsi_ptr: @jsi_ptr,
         )
       else
-        modified_jsi_root_node = @jsi_root_node.modified_copy do |root|
+        modified_jsi_root_node = @jsi_root_node.jsi_modified_copy do |root|
           @jsi_ptr.modified_document_copy(root, &block)
         end
         self.class.new(Base::NOINSTANCE, jsi_document: modified_jsi_root_node.jsi_document, jsi_ptr: @jsi_ptr, jsi_root_node: modified_jsi_root_node)
@@ -346,7 +346,7 @@ module JSI
     end
 
     def dup
-      modified_copy(&:dup)
+      jsi_modified_copy(&:dup)
     end
 
     # @return [String] a string representing this JSI, indicating its class

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -352,14 +352,14 @@ module JSI
     # @return [String] a string representing this JSI, indicating its class
     #   and inspecting its instance
     def inspect
-      "\#<#{object_group_text.join(' ')} #{jsi_instance.inspect}>"
+      "\#<#{jsi_object_group_text.join(' ')} #{jsi_instance.inspect}>"
     end
 
     # pretty-prints a representation this JSI to the given printer
     # @return [void]
     def pretty_print(q)
       q.text '#<'
-      q.text object_group_text.join(' ')
+      q.text jsi_object_group_text.join(' ')
       q.group_sub {
         q.nest(2) {
           q.breakable ' '
@@ -371,7 +371,7 @@ module JSI
     end
 
     # @return [Array<String>]
-    def object_group_text
+    def jsi_object_group_text
       class_name = self.class.name unless self.class.in_schema_classes
       class_txt = begin
         if class_name
@@ -393,8 +393,8 @@ module JSI
       end
 
       if (is_a?(PathedArrayNode) || is_a?(PathedHashNode)) && ![Array, Hash].include?(jsi_node_content.class)
-        if jsi_node_content.respond_to?(:object_group_text)
-          content_txt = jsi_node_content.object_group_text
+        if jsi_node_content.respond_to?(:jsi_object_group_text)
+          content_txt = jsi_node_content.jsi_object_group_text
         else
           content_txt = [jsi_node_content.class.to_s]
         end

--- a/lib/jsi/json/node.rb
+++ b/lib/jsi/json/node.rb
@@ -152,22 +152,22 @@ module JSI
 
       # meta-information about the object, outside the content. used by #inspect / #pretty_print
       # @return [Array<String>]
-      def object_group_text
+      def jsi_object_group_text
         [
           self.class.inspect,
           jsi_ptr.uri.to_s,
-        ] + (jsi_node_content.respond_to?(:object_group_text) ? jsi_node_content.object_group_text : [])
+        ] + (jsi_node_content.respond_to?(:jsi_object_group_text) ? jsi_node_content.jsi_object_group_text : [])
       end
 
       # a string representing this node
       def inspect
-        "\#<#{object_group_text.join(' ')} #{jsi_node_content.inspect}>"
+        "\#<#{jsi_object_group_text.join(' ')} #{jsi_node_content.inspect}>"
       end
 
       # pretty-prints a representation this node to the given printer
       def pretty_print(q)
         q.text '#<'
-        q.text object_group_text.join(' ')
+        q.text jsi_object_group_text.join(' ')
         q.group_sub {
           q.nest(2) {
             q.breakable ' '

--- a/lib/jsi/json/node.rb
+++ b/lib/jsi/json/node.rb
@@ -75,7 +75,7 @@ module JSI
       # not a key of the hash, then the $ref is followed before returning the subcontent.
       def [](subscript)
         ptr = self.jsi_ptr
-        content = self.node_content
+        content = self.jsi_node_content
         unless content.respond_to?(:[])
           if content.respond_to?(:to_hash)
             content = content.to_hash
@@ -102,9 +102,9 @@ module JSI
       # assigns the given subscript of the content to the given value. the document is modified in place.
       def []=(subscript, value)
         if value.is_a?(Node)
-          node_content[subscript] = value.node_content
+          jsi_node_content[subscript] = value.jsi_node_content
         else
-          node_content[subscript] = value
+          jsi_node_content[subscript] = value
         end
       end
 
@@ -137,7 +137,7 @@ module JSI
 
       # returns a jsonifiable representation of this node's content
       def as_json(*opt)
-        Typelike.as_json(node_content, *opt)
+        Typelike.as_json(jsi_node_content, *opt)
       end
 
       # takes a block. the block is yielded the content of this node. the block MUST return a modified
@@ -156,12 +156,12 @@ module JSI
         [
           self.class.inspect,
           jsi_ptr.uri.to_s,
-        ] + (node_content.respond_to?(:object_group_text) ? node_content.object_group_text : [])
+        ] + (jsi_node_content.respond_to?(:object_group_text) ? jsi_node_content.object_group_text : [])
       end
 
       # a string representing this node
       def inspect
-        "\#<#{object_group_text.join(' ')} #{node_content.inspect}>"
+        "\#<#{object_group_text.join(' ')} #{jsi_node_content.inspect}>"
       end
 
       # pretty-prints a representation this node to the given printer
@@ -171,7 +171,7 @@ module JSI
         q.group_sub {
           q.nest(2) {
             q.breakable ' '
-            q.pp node_content
+            q.pp jsi_node_content
           }
         }
         q.breakable ''

--- a/lib/jsi/json/node.rb
+++ b/lib/jsi/json/node.rb
@@ -125,7 +125,7 @@ module JSI
       end
 
       # a Node at the root of the document
-      def document_root_node
+      def jsi_root_node
         Node.new_doc(jsi_document)
       end
 

--- a/lib/jsi/json/node.rb
+++ b/lib/jsi/json/node.rb
@@ -142,12 +142,12 @@ module JSI
 
       # takes a block. the block is yielded the content of this node. the block MUST return a modified
       # copy of that content (and NOT modify the object it is given).
-      def modified_copy(&block)
+      def jsi_modified_copy(&block)
         Node.new_by_type(jsi_ptr.modified_document_copy(jsi_document, &block), jsi_ptr)
       end
 
       def dup
-        modified_copy(&:dup)
+        jsi_modified_copy(&:dup)
       end
 
       # meta-information about the object, outside the content. used by #inspect / #pretty_print

--- a/lib/jsi/json/node.rb
+++ b/lib/jsi/json/node.rb
@@ -131,7 +131,7 @@ module JSI
 
       # the parent of this node. if this node is the document root, raises
       # JSI::JSON::Pointer::ReferenceError.
-      def parent_node
+      def jsi_parent_node
         Node.new_by_type(jsi_document, jsi_ptr.parent)
       end
 

--- a/lib/jsi/metaschema_node.rb
+++ b/lib/jsi/metaschema_node.rb
@@ -115,7 +115,7 @@ module JSI
     end
 
     # @return [MetaschemaNode] parent MetaschemaNode
-    def parent_node
+    def jsi_parent_node
       new_node(jsi_ptr: jsi_ptr.parent)
     end
 

--- a/lib/jsi/metaschema_node.rb
+++ b/lib/jsi/metaschema_node.rb
@@ -163,7 +163,7 @@ module JSI
     # @yield [Object] the node content of the instance. the block should result
     #   in a (nondestructively) modified copy of this.
     # @return [MetaschemaNode] modified copy of self
-    def modified_copy(&block)
+    def jsi_modified_copy(&block)
       MetaschemaNode.new(jsi_ptr.modified_document_copy(jsi_document, &block), our_initialize_params)
     end
 

--- a/lib/jsi/metaschema_node.rb
+++ b/lib/jsi/metaschema_node.rb
@@ -110,7 +110,7 @@ module JSI
     attr_reader :jsi_schemas
 
     # @return [MetaschemaNode] document root MetaschemaNode
-    def document_root_node
+    def jsi_root_node
       new_node(jsi_ptr: JSI::JSON::Pointer[])
     end
 

--- a/lib/jsi/metaschema_node.rb
+++ b/lib/jsi/metaschema_node.rb
@@ -40,11 +40,11 @@ module JSI
       @metaschema_root_ptr = metaschema_root_ptr
       @root_schema_ptr = root_schema_ptr
 
-      node_content = self.node_content
+      jsi_node_content = self.jsi_node_content
 
-      if node_content.respond_to?(:to_hash)
+      if jsi_node_content.respond_to?(:to_hash)
         extend PathedHashNode
-      elsif node_content.respond_to?(:to_ary)
+      elsif jsi_node_content.respond_to?(:to_ary)
         extend PathedArrayNode
       end
 
@@ -125,13 +125,13 @@ module JSI
     #   returns that value as a MetaschemaNode instantiation of that subschema.
     def [](token)
       if respond_to?(:to_hash)
-        token_in_range = node_content_hash_pubsend(:key?, token)
-        value = node_content_hash_pubsend(:[], token)
+        token_in_range = jsi_node_content_hash_pubsend(:key?, token)
+        value = jsi_node_content_hash_pubsend(:[], token)
       elsif respond_to?(:to_ary)
-        token_in_range = node_content_ary_pubsend(:each_index).include?(token)
-        value = node_content_ary_pubsend(:[], token)
+        token_in_range = jsi_node_content_ary_pubsend(:each_index).include?(token)
+        value = jsi_node_content_ary_pubsend(:[], token)
       else
-        raise(NoMethodError, "cannot subcript (using token: #{token.inspect}) from content: #{node_content.pretty_inspect.chomp}")
+        raise(NoMethodError, "cannot subcript (using token: #{token.inspect}) from content: #{jsi_node_content.pretty_inspect.chomp}")
       end
 
       result = jsi_memoize(:[], token, value, token_in_range) do |token, value, token_in_range|
@@ -169,7 +169,7 @@ module JSI
 
     # @return [String]
     def inspect
-      "\#<#{object_group_text.join(' ')} #{node_content.inspect}>"
+      "\#<#{object_group_text.join(' ')} #{jsi_node_content.inspect}>"
     end
 
     def pretty_print(q)
@@ -178,7 +178,7 @@ module JSI
       q.group_sub {
         q.nest(2) {
           q.breakable ' '
-          q.pp node_content
+          q.pp jsi_node_content
         }
       }
       q.breakable ''
@@ -195,7 +195,7 @@ module JSI
       [
         class_n_schemas,
         is_a?(Metaschema) ? "Metaschema" : is_a?(Schema) ? "Schema" : nil,
-        *(node_content.respond_to?(:object_group_text) ? node_content.object_group_text : []),
+        *(jsi_node_content.respond_to?(:object_group_text) ? jsi_node_content.object_group_text : []),
       ].compact
     end
 

--- a/lib/jsi/metaschema_node.rb
+++ b/lib/jsi/metaschema_node.rb
@@ -169,12 +169,12 @@ module JSI
 
     # @return [String]
     def inspect
-      "\#<#{object_group_text.join(' ')} #{jsi_node_content.inspect}>"
+      "\#<#{jsi_object_group_text.join(' ')} #{jsi_node_content.inspect}>"
     end
 
     def pretty_print(q)
       q.text '#<'
-      q.text object_group_text.join(' ')
+      q.text jsi_object_group_text.join(' ')
       q.group_sub {
         q.nest(2) {
           q.breakable ' '
@@ -186,7 +186,7 @@ module JSI
     end
 
     # @return [Array<String>]
-    def object_group_text
+    def jsi_object_group_text
       if jsi_schemas.any?
         class_n_schemas = "#{self.class} (#{jsi_schemas.map { |s| s.jsi_ptr.uri }.join(' ')})"
       else
@@ -195,7 +195,7 @@ module JSI
       [
         class_n_schemas,
         is_a?(Metaschema) ? "Metaschema" : is_a?(Schema) ? "Schema" : nil,
-        *(jsi_node_content.respond_to?(:object_group_text) ? jsi_node_content.object_group_text : []),
+        *(jsi_node_content.respond_to?(:jsi_object_group_text) ? jsi_node_content.jsi_object_group_text : []),
       ].compact
     end
 

--- a/lib/jsi/pathed_node.rb
+++ b/lib/jsi/pathed_node.rb
@@ -4,7 +4,7 @@ module JSI
   # including class MUST define
   # - #jsi_document [Object] returning the document
   # - #jsi_ptr [JSI::JSON::Pointer] returning a pointer for the node path in the document
-  # - #document_root_node [JSI::PathedNode] returning a PathedNode pointing at the document root
+  # - #jsi_root_node [JSI::PathedNode] returning a PathedNode pointing at the document root
   # - #parent_node [JSI::PathedNode] returning the parent node of this PathedNode
   # - #deref [JSI::PathedNode] following a $ref
   #

--- a/lib/jsi/pathed_node.rb
+++ b/lib/jsi/pathed_node.rb
@@ -2,8 +2,8 @@
 
 module JSI
   # including class MUST define
-  # - #node_document [Object] returning the document
-  # - #node_ptr [JSI::JSON::Pointer] returning a pointer for the node path in the document
+  # - #jsi_document [Object] returning the document
+  # - #jsi_ptr [JSI::JSON::Pointer] returning a pointer for the node path in the document
   # - #document_root_node [JSI::PathedNode] returning a PathedNode pointing at the document root
   # - #parent_node [JSI::PathedNode] returning the parent node of this PathedNode
   # - #deref [JSI::PathedNode] following a $ref
@@ -14,14 +14,14 @@ module JSI
   module PathedNode
     # @return [Object] the content of this node
     def node_content
-      content = node_ptr.evaluate(node_document)
+      content = jsi_ptr.evaluate(jsi_document)
       content
     end
 
     # @yield [JSI::JSON::Pointer] if a block is given (optional), this will yield a deref'd pointer
-    # @return [JSI::JSON::Pointer] our node_ptr, derefed against our node_document
-    def node_ptr_deref(&block)
-      node_ptr.deref(node_document, &block)
+    # @return [JSI::JSON::Pointer] our jsi_ptr, derefed against our jsi_document
+    def jsi_ptr_deref(&block)
+      jsi_ptr.deref(jsi_document, &block)
     end
   end
 

--- a/lib/jsi/pathed_node.rb
+++ b/lib/jsi/pathed_node.rb
@@ -10,10 +10,10 @@ module JSI
   #
   # given these, this module represents the node in the document at the path.
   #
-  # the node content (#node_content) is the result of evaluating the node document at the path.
+  # the node content (#jsi_node_content) is the result of evaluating the node document at the path.
   module PathedNode
     # @return [Object] the content of this node
-    def node_content
+    def jsi_node_content
       content = jsi_ptr.evaluate(jsi_document)
       content
     end
@@ -25,7 +25,7 @@ module JSI
     end
   end
 
-  # module extending a {JSI::PathedNode} object when its node_content is Hash-like (responds to #to_hash)
+  # module extending a {JSI::PathedNode} object when its jsi_node_content is Hash-like (responds to #to_hash)
   module PathedHashNode
     # yields each hash key and value of this node.
     #
@@ -37,16 +37,16 @@ module JSI
     # @yield [Object, Object] each key and value of this hash node
     # @return [self, Enumerator]
     def each(&block)
-      return to_enum(__method__) { node_content_hash_pubsend(:size) } unless block
+      return to_enum(__method__) { jsi_node_content_hash_pubsend(:size) } unless block
       if block.arity > 1
-        node_content_hash_pubsend(:each_key) { |k| yield k, self[k] }
+        jsi_node_content_hash_pubsend(:each_key) { |k| yield k, self[k] }
       else
-        node_content_hash_pubsend(:each_key) { |k| yield [k, self[k]] }
+        jsi_node_content_hash_pubsend(:each_key) { |k| yield [k, self[k]] }
       end
       self
     end
 
-    # @return [Hash] a hash in which each key is a key of the node_content hash and
+    # @return [Hash] a hash in which each key is a key of the jsi_node_content hash and
     #   each value is the result of self[key] (see #[]).
     def to_hash
       {}.tap { |h| each_key { |k| h[k] = self[k] } }
@@ -56,19 +56,19 @@ module JSI
 
     # @param method_name [String, Symbol]
     # @param *a, &b are passed to the invocation of method_name
-    # @return [Object] the result of calling method method_name on the node_content or its #to_hash
-    def node_content_hash_pubsend(method_name, *a, &b)
-      if node_content.respond_to?(method_name)
-        node_content.public_send(method_name, *a, &b)
+    # @return [Object] the result of calling method method_name on the jsi_node_content or its #to_hash
+    def jsi_node_content_hash_pubsend(method_name, *a, &b)
+      if jsi_node_content.respond_to?(method_name)
+        jsi_node_content.public_send(method_name, *a, &b)
       else
-        node_content.to_hash.public_send(method_name, *a, &b)
+        jsi_node_content.to_hash.public_send(method_name, *a, &b)
       end
     end
 
     # methods that don't look at the value; can skip the overhead of #[] (invoked by #to_hash)
     SAFE_KEY_ONLY_METHODS.each do |method_name|
       define_method(method_name) do |*a, &b|
-        node_content_hash_pubsend(method_name, *a, &b)
+        jsi_node_content_hash_pubsend(method_name, *a, &b)
       end
     end
   end
@@ -83,12 +83,12 @@ module JSI
     # @yield [Object] each element of this array node
     # @return [self, Enumerator]
     def each(&block)
-      return to_enum(__method__) { node_content_ary_pubsend(:size) } unless block
-      node_content_ary_pubsend(:each_index) { |i| yield(self[i]) }
+      return to_enum(__method__) { jsi_node_content_ary_pubsend(:size) } unless block
+      jsi_node_content_ary_pubsend(:each_index) { |i| yield(self[i]) }
       self
     end
 
-    # @return [Array] an array, the same size as the node_content, in which the
+    # @return [Array] an array, the same size as the jsi_node_content, in which the
     #   element at each index is the result of self[index] (see #[])
     def to_ary
       to_a
@@ -98,12 +98,12 @@ module JSI
 
     # @param method_name [String, Symbol]
     # @param *a, &b are passed to the invocation of method_name
-    # @return [Object] the result of calling method method_name on the node_content or its #to_ary
-    def node_content_ary_pubsend(method_name, *a, &b)
-      if node_content.respond_to?(method_name)
-        node_content.public_send(method_name, *a, &b)
+    # @return [Object] the result of calling method method_name on the jsi_node_content or its #to_ary
+    def jsi_node_content_ary_pubsend(method_name, *a, &b)
+      if jsi_node_content.respond_to?(method_name)
+        jsi_node_content.public_send(method_name, *a, &b)
       else
-        node_content.to_ary.public_send(method_name, *a, &b)
+        jsi_node_content.to_ary.public_send(method_name, *a, &b)
       end
     end
 
@@ -111,7 +111,7 @@ module JSI
     # we override these methods from Arraylike
     SAFE_INDEX_ONLY_METHODS.each do |method_name|
       define_method(method_name) do |*a, &b|
-        node_content_ary_pubsend(method_name, *a, &b)
+        jsi_node_content_ary_pubsend(method_name, *a, &b)
       end
     end
   end

--- a/lib/jsi/pathed_node.rb
+++ b/lib/jsi/pathed_node.rb
@@ -5,7 +5,7 @@ module JSI
   # - #jsi_document [Object] returning the document
   # - #jsi_ptr [JSI::JSON::Pointer] returning a pointer for the node path in the document
   # - #jsi_root_node [JSI::PathedNode] returning a PathedNode pointing at the document root
-  # - #parent_node [JSI::PathedNode] returning the parent node of this PathedNode
+  # - #jsi_parent_node [JSI::PathedNode] returning the parent node of this PathedNode
   # - #deref [JSI::PathedNode] following a $ref
   #
   # given these, this module represents the node in the document at the path.

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -97,10 +97,10 @@ module JSI
               node_content_for_id.key?('id') && node_content_for_id['id'].respond_to?(:to_str) ? node_content_for_id['id'].to_str : nil
           end
 
-          if parent_id || node_for_id.node_ptr.root?
+          if parent_id || node_for_id.jsi_ptr.root?
             done = true
           else
-            path_from_id_node.unshift(node_for_id.node_ptr.reference_tokens.last)
+            path_from_id_node.unshift(node_for_id.jsi_ptr.reference_tokens.last)
             node_for_id = node_for_id.parent_node
           end
         end
@@ -157,7 +157,7 @@ module JSI
     # @param other_instance [Object] the instance to check any applicators against
     # @return [Set<JSI::Schema>] matched applicator schemas
     def match_to_instance(other_instance)
-      node_ptr.schema_match_ptrs_to_instance(node_document, other_instance).map do |ptr|
+      jsi_ptr.schema_match_ptrs_to_instance(jsi_document, other_instance).map do |ptr|
         ptr.evaluate(document_root_node).tap { |subschema| jsi_ensure_subschema_is_schema(subschema, ptr) }
       end.to_set
     end
@@ -169,7 +169,7 @@ module JSI
     # @return [Set<JSI::Schema>] subschemas of this schema for the given property_name
     def subschemas_for_property_name(property_name)
       jsi_memoize(:subschemas_for_property_name, property_name) do |property_name|
-        node_ptr.schema_subschema_ptrs_for_property_name(node_document, property_name).map do |ptr|
+        jsi_ptr.schema_subschema_ptrs_for_property_name(jsi_document, property_name).map do |ptr|
           ptr.evaluate(document_root_node).tap { |subschema| jsi_ensure_subschema_is_schema(subschema, ptr) }
         end.to_set
       end
@@ -182,7 +182,7 @@ module JSI
     # @return [Set<JSI::Schema>] subschemas of this schema for the given array index
     def subschemas_for_index(index)
       jsi_memoize(:subschemas_for_index, index) do |index|
-        node_ptr.schema_subschema_ptrs_for_index(node_document, index).map do |ptr|
+        jsi_ptr.schema_subschema_ptrs_for_index(jsi_document, index).map do |ptr|
           ptr.evaluate(document_root_node).tap { |subschema| jsi_ensure_subschema_is_schema(subschema, ptr) }
         end.to_set
       end
@@ -207,12 +207,12 @@ module JSI
     # @return [Array] array of schema validation errors for
     #   the given instance against this schema
     def fully_validate_instance(other_instance, errors_as_objects: false)
-      ::JSON::Validator.fully_validate(JSI::Typelike.as_json(node_document), JSI::Typelike.as_json(other_instance), fragment: node_ptr.fragment, errors_as_objects: errors_as_objects)
+      ::JSON::Validator.fully_validate(JSI::Typelike.as_json(jsi_document), JSI::Typelike.as_json(other_instance), fragment: jsi_ptr.fragment, errors_as_objects: errors_as_objects)
     end
 
     # @return [true, false] whether the given instance validates against this schema
     def validate_instance(other_instance)
-      ::JSON::Validator.validate(JSI::Typelike.as_json(node_document), JSI::Typelike.as_json(other_instance), fragment: node_ptr.fragment)
+      ::JSON::Validator.validate(JSI::Typelike.as_json(jsi_document), JSI::Typelike.as_json(other_instance), fragment: jsi_ptr.fragment)
     end
 
     # @return [true] if this method does not raise, it returns true to
@@ -220,19 +220,19 @@ module JSI
     # @raise [::JSON::Schema::ValidationError] raises if the instance has
     #   validation errors against this schema
     def validate_instance!(other_instance)
-      ::JSON::Validator.validate!(JSI::Typelike.as_json(node_document), JSI::Typelike.as_json(other_instance), fragment: node_ptr.fragment)
+      ::JSON::Validator.validate!(JSI::Typelike.as_json(jsi_document), JSI::Typelike.as_json(other_instance), fragment: jsi_ptr.fragment)
     end
 
     # @return [Array] array of schema validation errors for
     #   this schema, validated against its metaschema. a default metaschema
     #   is assumed if the schema does not specify a $schema.
     def fully_validate_schema(errors_as_objects: false)
-      ::JSON::Validator.fully_validate(JSI::Typelike.as_json(node_document), [], fragment: node_ptr.fragment, validate_schema: true, list: true, errors_as_objects: errors_as_objects)
+      ::JSON::Validator.fully_validate(JSI::Typelike.as_json(jsi_document), [], fragment: jsi_ptr.fragment, validate_schema: true, list: true, errors_as_objects: errors_as_objects)
     end
 
     # @return [true, false] whether this schema validates against its metaschema
     def validate_schema
-      ::JSON::Validator.validate(JSI::Typelike.as_json(node_document), [], fragment: node_ptr.fragment, validate_schema: true, list: true)
+      ::JSON::Validator.validate(JSI::Typelike.as_json(jsi_document), [], fragment: jsi_ptr.fragment, validate_schema: true, list: true)
     end
 
     # @return [true] if this method does not raise, it returns true to
@@ -240,7 +240,7 @@ module JSI
     # @raise [::JSON::Schema::ValidationError] raises if this schema has
     #   validation errors against its metaschema
     def validate_schema!
-      ::JSON::Validator.validate!(JSI::Typelike.as_json(node_document), [], fragment: node_ptr.fragment, validate_schema: true, list: true)
+      ::JSON::Validator.validate!(JSI::Typelike.as_json(jsi_document), [], fragment: jsi_ptr.fragment, validate_schema: true, list: true)
     end
 
     private

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -158,7 +158,7 @@ module JSI
     # @return [Set<JSI::Schema>] matched applicator schemas
     def match_to_instance(other_instance)
       jsi_ptr.schema_match_ptrs_to_instance(jsi_document, other_instance).map do |ptr|
-        ptr.evaluate(document_root_node).tap { |subschema| jsi_ensure_subschema_is_schema(subschema, ptr) }
+        ptr.evaluate(jsi_root_node).tap { |subschema| jsi_ensure_subschema_is_schema(subschema, ptr) }
       end.to_set
     end
 
@@ -170,7 +170,7 @@ module JSI
     def subschemas_for_property_name(property_name)
       jsi_memoize(:subschemas_for_property_name, property_name) do |property_name|
         jsi_ptr.schema_subschema_ptrs_for_property_name(jsi_document, property_name).map do |ptr|
-          ptr.evaluate(document_root_node).tap { |subschema| jsi_ensure_subschema_is_schema(subschema, ptr) }
+          ptr.evaluate(jsi_root_node).tap { |subschema| jsi_ensure_subschema_is_schema(subschema, ptr) }
         end.to_set
       end
     end
@@ -183,7 +183,7 @@ module JSI
     def subschemas_for_index(index)
       jsi_memoize(:subschemas_for_index, index) do |index|
         jsi_ptr.schema_subschema_ptrs_for_index(jsi_document, index).map do |ptr|
-          ptr.evaluate(document_root_node).tap { |subschema| jsi_ensure_subschema_is_schema(subschema, ptr) }
+          ptr.evaluate(jsi_root_node).tap { |subschema| jsi_ensure_subschema_is_schema(subschema, ptr) }
         end.to_set
       end
     end

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -91,10 +91,10 @@ module JSI
         done = false
 
         while !done
-          node_content_for_id = node_for_id.node_content
-          if node_for_id.is_a?(JSI::Schema) && node_content_for_id.respond_to?(:to_hash)
-            parent_id = node_content_for_id.key?('$id') && node_content_for_id['$id'].respond_to?(:to_str) ? node_content_for_id['$id'].to_str :
-              node_content_for_id.key?('id') && node_content_for_id['id'].respond_to?(:to_str) ? node_content_for_id['id'].to_str : nil
+          content_for_id = node_for_id.jsi_node_content
+          if node_for_id.is_a?(JSI::Schema) && content_for_id.respond_to?(:to_hash)
+            parent_id = content_for_id.key?('$id') && content_for_id['$id'].respond_to?(:to_str) ? content_for_id['$id'].to_str :
+              content_for_id.key?('id') && content_for_id['id'].respond_to?(:to_str) ? content_for_id['id'].to_str : nil
           end
 
           if parent_id || node_for_id.jsi_ptr.root?
@@ -194,11 +194,11 @@ module JSI
     def described_object_property_names
       jsi_memoize(:described_object_property_names) do
         Set.new.tap do |property_names|
-          if node_content.respond_to?(:to_hash) && node_content['properties'].respond_to?(:to_hash)
-            property_names.merge(node_content['properties'].keys)
+          if jsi_node_content.respond_to?(:to_hash) && jsi_node_content['properties'].respond_to?(:to_hash)
+            property_names.merge(jsi_node_content['properties'].keys)
           end
-          if node_content.respond_to?(:to_hash) && node_content['required'].respond_to?(:to_ary)
-            property_names.merge(node_content['required'].to_ary)
+          if jsi_node_content.respond_to?(:to_hash) && jsi_node_content['required'].respond_to?(:to_ary)
+            property_names.merge(jsi_node_content['required'].to_ary)
           end
         end
       end

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -101,7 +101,7 @@ module JSI
             done = true
           else
             path_from_id_node.unshift(node_for_id.jsi_ptr.reference_tokens.last)
-            node_for_id = node_for_id.parent_node
+            node_for_id = node_for_id.jsi_parent_node
           end
         end
         if parent_id

--- a/lib/jsi/schema_classes.rb
+++ b/lib/jsi/schema_classes.rb
@@ -11,7 +11,7 @@ module JSI
 
     # @return [String]
     def inspect
-      uri = schema.schema_id || schema.node_ptr.uri
+      uri = schema.schema_id || schema.jsi_ptr.uri
       if name
         "#{name} (#{uri})"
       else

--- a/lib/jsi/typelike_modules.rb
+++ b/lib/jsi/typelike_modules.rb
@@ -39,7 +39,7 @@ module JSI
     #   array of object) cannot be expressed as json
     def self.as_json(object, *opt)
       if object.is_a?(JSI::PathedNode)
-        as_json(object.node_content, *opt)
+        as_json(object.jsi_node_content, *opt)
       elsif object.respond_to?(:to_hash)
         (object.respond_to?(:map) ? object : object.to_hash).map do |k, v|
           unless k.is_a?(Symbol) || k.respond_to?(:to_str)

--- a/lib/jsi/typelike_modules.rb
+++ b/lib/jsi/typelike_modules.rb
@@ -4,7 +4,7 @@ module JSI
   # a module relating to objects that act like Hash or Array instances
   module Typelike
     # yields the content of the given param `object`. for objects which have a
-    # #modified_copy method of their own (JSI::Base, JSI::JSON::Node) that
+    # #jsi_modified_copy method of their own (JSI::Base, JSI::JSON::Node) that
     # method is invoked with the given block. otherwise the given object itself
     # is yielded.
     #
@@ -15,8 +15,8 @@ module JSI
     #   in a (nondestructively) modified copy of this.
     # @return [object.class] modified copy of the given object
     def self.modified_copy(object, &block)
-      if object.respond_to?(:modified_copy)
-        object.modified_copy(&block)
+      if object.respond_to?(:jsi_modified_copy)
+        object.jsi_modified_copy(&block)
       else
         return yield(object)
       end
@@ -86,7 +86,7 @@ module JSI
     end
     safe_modified_copy_methods.each do |method_name|
       define_method(method_name) do |*a, &b|
-        modified_copy do |object_to_modify|
+        jsi_modified_copy do |object_to_modify|
           responsive_object = object_to_modify.respond_to?(method_name) ? object_to_modify : object_to_modify.to_hash
           responsive_object.public_send(method_name, *a, &b)
         end
@@ -94,7 +94,7 @@ module JSI
     end
     safe_kv_block_modified_copy_methods.each do |method_name|
       define_method(method_name) do |*a, &b|
-        modified_copy do |object_to_modify|
+        jsi_modified_copy do |object_to_modify|
           responsive_object = object_to_modify.respond_to?(method_name) ? object_to_modify : object_to_modify.to_hash
           responsive_object.public_send(method_name, *a) do |k, _v|
             b.call(k, self[k])
@@ -193,7 +193,7 @@ module JSI
     end
     safe_modified_copy_methods.each do |method_name|
       define_method(method_name) do |*a, &b|
-        modified_copy do |object_to_modify|
+        jsi_modified_copy do |object_to_modify|
           responsive_object = object_to_modify.respond_to?(method_name) ? object_to_modify : object_to_modify.to_ary
           responsive_object.public_send(method_name, *a, &b)
         end
@@ -201,7 +201,7 @@ module JSI
     end
     safe_el_block_methods.each do |method_name|
       define_method(method_name) do |*a, &b|
-        modified_copy do |object_to_modify|
+        jsi_modified_copy do |object_to_modify|
           i = 0
           responsive_object = object_to_modify.respond_to?(method_name) ? object_to_modify : object_to_modify.to_ary
           responsive_object.public_send(method_name, *a) do |_e|

--- a/lib/jsi/typelike_modules.rb
+++ b/lib/jsi/typelike_modules.rb
@@ -136,9 +136,9 @@ module JSI
     end
 
     # @return [String] basically the same #inspect as Hash, but has the
-    #   class name and, if responsive, self's #object_group_text
+    #   class name and, if responsive, self's #jsi_object_group_text
     def inspect
-      object_group_str = (respond_to?(:object_group_text) ? self.object_group_text : [self.class]).join(' ')
+      object_group_str = (respond_to?(:jsi_object_group_text) ? self.jsi_object_group_text : [self.class]).join(' ')
       "\#{<#{object_group_str}>#{empty? ? '' : ' '}#{self.map { |k, v| "#{k.inspect} => #{v.inspect}" }.join(', ')}}"
     end
 
@@ -147,7 +147,7 @@ module JSI
     # pretty-prints a representation this node to the given printer
     # @return [void]
     def pretty_print(q)
-      object_group_str = (respond_to?(:object_group_text) ? object_group_text : [self.class]).join(' ')
+      object_group_str = (respond_to?(:jsi_object_group_text) ? jsi_object_group_text : [self.class]).join(' ')
       q.text "\#{<#{object_group_str}>"
       q.group_sub {
         q.nest(2) {
@@ -212,9 +212,9 @@ module JSI
     end
 
     # @return [String] basically the same #inspect as Array, but has the
-    #   class name and, if responsive, self's #object_group_text
+    #   class name and, if responsive, self's #jsi_object_group_text
     def inspect
-      object_group_str = (respond_to?(:object_group_text) ? object_group_text : [self.class]).join(' ')
+      object_group_str = (respond_to?(:jsi_object_group_text) ? jsi_object_group_text : [self.class]).join(' ')
       "\#[<#{object_group_str}>#{empty? ? '' : ' '}#{self.map { |e| e.inspect }.join(', ')}]"
     end
 
@@ -223,7 +223,7 @@ module JSI
     # pretty-prints a representation this node to the given printer
     # @return [void]
     def pretty_print(q)
-      object_group_str = (respond_to?(:object_group_text) ? object_group_text : [self.class]).join(' ')
+      object_group_str = (respond_to?(:jsi_object_group_text) ? jsi_object_group_text : [self.class]).join(' ')
       q.text "\#[<#{object_group_str}>"
       q.group_sub {
         q.nest(2) {

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -152,31 +152,25 @@ describe JSI::Base do
       end
     end
   end
-  describe '#parent_jsis, #parent_jsi' do
+  describe '#jsi_parent_nodes, #jsi_parent_node' do
     let(:schema_content) { {'properties' => {'foo' => {'properties' => {'bar' => {'properties' => {'baz' => {}}}}}}} }
     let(:instance) { {'foo' => {'bar' => {'baz' => {}}}} }
-    describe 'no parent_jsis' do
+    describe 'no jsi_parent_nodes' do
       it 'has none' do
-        assert_equal([], subject.parents)
-        assert_equal([], subject.parent_jsis)
-        assert_equal(nil, subject.parent)
-        assert_equal(nil, subject.parent_jsi)
+        assert_equal([], subject.jsi_parent_nodes)
+        assert_equal(nil, subject.jsi_parent_node)
       end
     end
-    describe 'one parent_jsi' do
+    describe 'one jsi_parent_node' do
       it 'has one' do
-        assert_equal([subject], subject.foo.parents)
-        assert_equal([subject], subject.foo.parent_jsis)
-        assert_equal(subject, subject.foo.parent)
-        assert_equal(subject, subject.foo.parent_jsi)
+        assert_equal([subject], subject.foo.jsi_parent_nodes)
+        assert_equal(subject, subject.foo.jsi_parent_node)
       end
     end
-    describe 'more parent_jsis' do
+    describe 'more jsi_parent_nodes' do
       it 'has more' do
-        assert_equal([subject.foo.bar, subject.foo, subject], subject.foo.bar.baz.parents)
-        assert_equal([subject.foo.bar, subject.foo, subject], subject.foo.bar.baz.parent_jsis)
-        assert_equal(subject.foo.bar, subject.foo.bar.baz.parent)
-        assert_equal(subject.foo.bar, subject.foo.bar.baz.parent_jsi)
+        assert_equal([subject.foo.bar, subject.foo, subject], subject.foo.bar.baz.jsi_parent_nodes)
+        assert_equal(subject.foo.bar, subject.foo.bar.baz.jsi_parent_node)
       end
     end
   end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -181,12 +181,12 @@ describe JSI::Base do
       assert_raises(NoMethodError) { subject.map { nil } }
     end
   end
-  describe '#modified_copy' do
-    describe 'with an instance that does not have #modified_copy' do
+  describe '#jsi_modified_copy' do
+    describe 'with an instance that does not have #jsi_modified_copy' do
       let(:instance) { Object.new }
       it 'yields the instance to modify' do
         new_instance = Object.new
-        modified = subject.modified_copy do |o|
+        modified = subject.jsi_modified_copy do |o|
           assert_equal(instance, o)
           new_instance
         end
@@ -195,9 +195,9 @@ describe JSI::Base do
         refute_equal(instance, modified)
       end
     end
-    describe 'with an instance that does have #modified_copy' do
+    describe 'with an instance that does have #jsi_modified_copy' do
       it 'yields the instance to modify' do
-        modified = subject.modified_copy do |o|
+        modified = subject.jsi_modified_copy do |o|
           assert_equal({}, o)
           {'a' => 'b'}
         end
@@ -208,7 +208,7 @@ describe JSI::Base do
     end
     describe 'no modification' do
       it 'yields the instance to modify' do
-        modified = subject.modified_copy { |o| o }
+        modified = subject.jsi_modified_copy { |o| o }
         # this doesn't really need to be tested but ... whatever
         assert_equal(subject.jsi_instance.object_id, modified.jsi_instance.object_id)
         assert_equal(subject, modified)
@@ -219,7 +219,7 @@ describe JSI::Base do
       let(:schema_content) { {'type' => 'object'} }
       it 'works' do
         # I'm not really sure the best thing to do here, but this is how it is for now. this is subject to change.
-        modified = subject.modified_copy do |o|
+        modified = subject.jsi_modified_copy do |o|
           o.to_s
         end
         assert_equal('{}', modified.jsi_instance)

--- a/test/jsi_json_arraynode_test.rb
+++ b/test/jsi_json_arraynode_test.rb
@@ -3,24 +3,24 @@ require_relative 'test_helper'
 document_types = [
   {
     make_document: -> (d) { d },
-    node_document: ['a', ['b', 'q'], {'c' => {'d' => 'e'}}],
+    jsi_document: ['a', ['b', 'q'], {'c' => {'d' => 'e'}}],
     type_desc: 'Array',
   },
   {
     make_document: -> (d) { SortOfArray.new(d) },
-    node_document: SortOfArray.new(['a', SortOfArray.new(['b', 'q']), SortOfHash.new({'c' => SortOfHash.new({'d' => 'e'})})]),
+    jsi_document: SortOfArray.new(['a', SortOfArray.new(['b', 'q']), SortOfHash.new({'c' => SortOfHash.new({'d' => 'e'})})]),
     type_desc: 'sort of Array-like',
   },
 ]
 document_types.each do |document_type|
   describe "JSI::JSON::ArrayNode with #{document_type[:type_desc]}" do
-    # node_document of the node being tested
-    let(:node_document) { document_type[:node_document] }
+    # jsi_document of the node being tested
+    let(:jsi_document) { document_type[:jsi_document] }
     # by default the node is the whole document
     let(:path) { [] }
-    let(:node_ptr) { JSI::JSON::Pointer.new(path) }
+    let(:jsi_ptr) { JSI::JSON::Pointer.new(path) }
     # the node being tested
-    let(:node) { JSI::JSON::Node.new_by_type(node_document, node_ptr) }
+    let(:node) { JSI::JSON::Node.new_by_type(jsi_document, jsi_ptr) }
 
     describe '#[] bad index' do
       it 'improves TypeError for Array subsript' do
@@ -56,7 +56,7 @@ document_types.each do |document_type|
       end
     end
     describe '#as_json' do
-      let(:node_document) { document_type[:make_document].call(['a', 'b']) }
+      let(:jsi_document) { document_type[:make_document].call(['a', 'b']) }
       it '#as_json' do
         assert_equal(['a', 'b'], node.as_json)
         assert_equal(['a', 'b'], node.as_json(some_option: false))
@@ -132,11 +132,11 @@ document_types.each do |document_type|
       it('#select')  { assert_equal(JSI::JSON::Node.new_doc(['a']), node.select { |e| e == 'a' }) }
       it('#compact') { assert_equal(JSI::JSON::Node.new_doc(node.node_content.to_ary), node.compact) }
       describe 'at a depth' do
-        let(:node_document) { document_type[:make_document].call([['b', 'q'], {'c' => ['d', 'e']}]) }
+        let(:jsi_document) { document_type[:make_document].call([['b', 'q'], {'c' => ['d', 'e']}]) }
         let(:path) { ['1', 'c'] }
         it('#select') do
           selected = node.select { |e| e == 'd' }
-          equivalent = JSI::JSON::Node.new_by_type([['b', 'q'], {'c' => ['d']}], node_ptr)
+          equivalent = JSI::JSON::Node.new_by_type([['b', 'q'], {'c' => ['d']}], jsi_ptr)
           assert_equal(equivalent, selected)
         end
       end

--- a/test/jsi_json_arraynode_test.rb
+++ b/test/jsi_json_arraynode_test.rb
@@ -130,7 +130,7 @@ document_types.each do |document_type|
     describe 'modified copy methods' do
       it('#reject')  { assert_equal(JSI::JSON::Node.new_doc(['a']), node.reject { |e| e != 'a' }) }
       it('#select')  { assert_equal(JSI::JSON::Node.new_doc(['a']), node.select { |e| e == 'a' }) }
-      it('#compact') { assert_equal(JSI::JSON::Node.new_doc(node.node_content.to_ary), node.compact) }
+      it('#compact') { assert_equal(JSI::JSON::Node.new_doc(node.jsi_node_content.to_ary), node.compact) }
       describe 'at a depth' do
         let(:jsi_document) { document_type[:make_document].call([['b', 'q'], {'c' => ['d', 'e']}]) }
         let(:path) { ['1', 'c'] }

--- a/test/jsi_json_hashnode_test.rb
+++ b/test/jsi_json_hashnode_test.rb
@@ -60,7 +60,7 @@ document_types.each do |document_type|
       let(:path) { ['c'] }
       it 'merges' do
         merged = node.merge('x' => 'y')
-        # check the node_content at 'c' was merged with the remainder of the document intact (at 'a')
+        # check the jsi_node_content at 'c' was merged with the remainder of the document intact (at 'a')
         assert_equal({'a' => {'b' => 0}, 'c' => {'d' => 'e', 'x' => 'y'}}, merged.jsi_document)
         # check the original node retains its original document
         assert_equal(document_type[:make_document].call({'a' => {'b' => 0}, 'c' => {'d' => 'e'}}), node.jsi_document)
@@ -115,12 +115,12 @@ document_types.each do |document_type|
     describe 'modified copy methods' do
       # I'm going to rely on the #merge test above to test the modified copy functionality and just do basic
       # tests of all the modified copy methods here
-      it('#merge') { assert_equal(JSI::JSON::Node.new_doc(node.node_content), node.merge({})) }
+      it('#merge') { assert_equal(JSI::JSON::Node.new_doc(node.jsi_node_content), node.merge({})) }
       it('#reject') { assert_equal(JSI::JSON::Node.new_doc({}), node.reject { true }) }
       it('#select') { assert_equal(JSI::JSON::Node.new_doc({}), node.select { false }) }
       # Hash#compact only available as of ruby 2.5.0
       if {}.respond_to?(:compact)
-        it('#compact') { assert_equal(JSI::JSON::Node.new_doc({"a" => "b", "c" => node.node_content.to_hash["c"]}), node.compact) }
+        it('#compact') { assert_equal(JSI::JSON::Node.new_doc({"a" => "b", "c" => node.jsi_node_content.to_hash["c"]}), node.compact) }
       end
     end
     JSI::Hashlike::DESTRUCTIVE_METHODS.each do |destructive_method_name|

--- a/test/jsi_json_hashnode_test.rb
+++ b/test/jsi_json_hashnode_test.rb
@@ -3,24 +3,24 @@ require_relative 'test_helper'
 document_types = [
   {
     make_document: -> (d) { d },
-    node_document: {'a' => 'b', 'c' => {'d' => 'e'}},
+    jsi_document: {'a' => 'b', 'c' => {'d' => 'e'}},
     type_desc: 'Hash',
   },
   {
     make_document: -> (d) { SortOfHash.new(d) },
-    node_document: SortOfHash.new({'a' => 'b', 'c' => SortOfHash.new({'d' => 'e'})}),
+    jsi_document: SortOfHash.new({'a' => 'b', 'c' => SortOfHash.new({'d' => 'e'})}),
     type_desc: 'sort of Hash-like',
   },
 ]
 document_types.each do |document_type|
   describe "JSI::JSON::HashNode with #{document_type[:type_desc]}" do
-    # node_document of the node being tested
-    let(:node_document) { document_type[:node_document] }
+    # jsi_document of the node being tested
+    let(:jsi_document) { document_type[:jsi_document] }
     # by default the node is the whole document
     let(:path) { [] }
-    let(:node_ptr) { JSI::JSON::Pointer.new(path) }
+    let(:jsi_ptr) { JSI::JSON::Pointer.new(path) }
     # the node being tested
-    let(:node) { JSI::JSON::Node.new_by_type(node_document, node_ptr) }
+    let(:node) { JSI::JSON::Node.new_by_type(jsi_document, jsi_ptr) }
 
     describe '#each' do
       it 'iterates, one argument' do
@@ -55,21 +55,21 @@ document_types.each do |document_type|
       end
     end
     describe '#merge' do
-      let(:node_document) { document_type[:make_document].call({'a' => {'b' => 0}, 'c' => {'d' => 'e'}}) }
+      let(:jsi_document) { document_type[:make_document].call({'a' => {'b' => 0}, 'c' => {'d' => 'e'}}) }
       # testing the node at 'c' here, merging a hash at a path within a document.
       let(:path) { ['c'] }
       it 'merges' do
         merged = node.merge('x' => 'y')
         # check the node_content at 'c' was merged with the remainder of the document intact (at 'a')
-        assert_equal({'a' => {'b' => 0}, 'c' => {'d' => 'e', 'x' => 'y'}}, merged.node_document)
+        assert_equal({'a' => {'b' => 0}, 'c' => {'d' => 'e', 'x' => 'y'}}, merged.jsi_document)
         # check the original node retains its original document
-        assert_equal(document_type[:make_document].call({'a' => {'b' => 0}, 'c' => {'d' => 'e'}}), node.node_document)
+        assert_equal(document_type[:make_document].call({'a' => {'b' => 0}, 'c' => {'d' => 'e'}}), node.jsi_document)
         # check that unnecessary copies of unaffected parts of the document were not made
-        assert_equal(node.node_document.to_hash['a'].object_id, merged.node_document['a'].object_id)
+        assert_equal(node.jsi_document.to_hash['a'].object_id, merged.jsi_document['a'].object_id)
       end
     end
     describe '#as_json' do
-      let(:node_document) { document_type[:make_document].call({'a' => 'b'}) }
+      let(:jsi_document) { document_type[:make_document].call({'a' => 'b'}) }
       it '#as_json' do
         assert_equal({'a' => 'b'}, node.as_json)
         assert_equal({'a' => 'b'}, node.as_json(this_option: 'what?'))

--- a/test/jsi_json_node_test.rb
+++ b/test/jsi_json_node_test.rb
@@ -149,10 +149,10 @@ describe JSI::JSON::Node do
       assert_equal([0, {'x' => [{'a' => ['b']}], 'y' => {'a' => ['b']}}], jsi_document)
     end
   end
-  describe '#document_root_node' do
+  describe '#jsi_root_node' do
     let(:jsi_document) { {'a' => {'b' => 3}} }
     it 'has node_content that is the jsi_document' do
-      assert_equal({'a' => {'b' => 3}}, node['a'].document_root_node.node_content)
+      assert_equal({'a' => {'b' => 3}}, node['a'].jsi_root_node.node_content)
     end
   end
   describe '#parent_node' do
@@ -188,7 +188,7 @@ describe JSI::JSON::Node do
       refute_equal(node.parent_node.node_content.object_id, modified_dup.parent_node.node_content.object_id)
       refute_equal(node.parent_node.parent_node.node_content.object_id, modified_dup.parent_node.parent_node.node_content.object_id)
       # but any untouched part(s) - in this case the ['b', 'q'] at jsi_document[0] - are untouched
-      assert_equal(node.document_root_node[0].node_content.object_id, modified_dup.document_root_node[0].node_content.object_id)
+      assert_equal(node.jsi_root_node[0].node_content.object_id, modified_dup.jsi_root_node[0].node_content.object_id)
     end
     it 'returns the same object' do
       unmodified_dup = node.modified_copy { |o| o }
@@ -199,7 +199,7 @@ describe JSI::JSON::Node do
       assert_equal(node.parent_node.node_content.object_id, unmodified_dup.parent_node.node_content.object_id)
       assert_equal(node.parent_node.parent_node.node_content.object_id, unmodified_dup.parent_node.parent_node.node_content.object_id)
       # same as the other: any untouched part(s) - in this case the ['b', 'q'] at jsi_document[0] - are untouched
-      assert_equal(node.document_root_node[0].node_content.object_id, unmodified_dup.document_root_node[0].node_content.object_id)
+      assert_equal(node.jsi_root_node[0].node_content.object_id, unmodified_dup.jsi_root_node[0].node_content.object_id)
     end
     it 'raises subscripting string from array' do
       err = assert_raises(TypeError) { JSI::JSON::Node.new(jsi_document, JSI::JSON::Pointer.new(['x'])).modified_copy(&:dup) }

--- a/test/jsi_json_node_test.rb
+++ b/test/jsi_json_node_test.rb
@@ -174,12 +174,12 @@ describe JSI::JSON::Node do
       assert_equal('cannot access parent of root pointer: JSI::JSON::Pointer[]', err.message)
     end
   end
-  describe '#modified_copy' do
+  describe '#jsi_modified_copy' do
     let(:jsi_document) { [['b', 'q'], {'c' => ['d', 'e']}] }
     let(:path) { ['1', 'c'] }
     it 'returns a different object' do
       # simplest thing
-      modified_dup = node.modified_copy(&:dup)
+      modified_dup = node.jsi_modified_copy(&:dup)
       # it is equal - being a dup
       assert_equal(node, modified_dup)
       # but different object
@@ -191,7 +191,7 @@ describe JSI::JSON::Node do
       assert_equal(node.jsi_root_node[0].jsi_node_content.object_id, modified_dup.jsi_root_node[0].jsi_node_content.object_id)
     end
     it 'returns the same object' do
-      unmodified_dup = node.modified_copy { |o| o }
+      unmodified_dup = node.jsi_modified_copy { |o| o }
       assert_equal(unmodified_dup, node)
       # same object, since the block just returned it
       refute_equal(node.object_id, unmodified_dup.object_id)
@@ -202,11 +202,11 @@ describe JSI::JSON::Node do
       assert_equal(node.jsi_root_node[0].jsi_node_content.object_id, unmodified_dup.jsi_root_node[0].jsi_node_content.object_id)
     end
     it 'raises subscripting string from array' do
-      err = assert_raises(TypeError) { JSI::JSON::Node.new(jsi_document, JSI::JSON::Pointer.new(['x'])).modified_copy(&:dup) }
+      err = assert_raises(TypeError) { JSI::JSON::Node.new(jsi_document, JSI::JSON::Pointer.new(['x'])).jsi_modified_copy(&:dup) }
       assert_match(%r(\Abad subscript "x" with remaining subpath: \[\] for array: \[.*\]\z)m, err.message)
     end
     it 'raises subscripting from invalid subpath' do
-      err = assert_raises(TypeError) { JSI::JSON::Node.new(jsi_document, JSI::JSON::Pointer.new([0, 0, 'what'])).modified_copy(&:dup) }
+      err = assert_raises(TypeError) { JSI::JSON::Node.new(jsi_document, JSI::JSON::Pointer.new([0, 0, 'what'])).jsi_modified_copy(&:dup) }
       assert_match(%r(bad subscript: "what" with remaining subpath: \[\] for content: "b"\z)m, err.message)
     end
   end

--- a/test/jsi_json_node_test.rb
+++ b/test/jsi_json_node_test.rb
@@ -155,21 +155,21 @@ describe JSI::JSON::Node do
       assert_equal({'a' => {'b' => 3}}, node['a'].jsi_root_node.node_content)
     end
   end
-  describe '#parent_node' do
+  describe '#jsi_parent_node' do
     let(:jsi_document) { {'a' => {'b' => []}} }
     it 'finds a parent' do
       sub = node['a']['b']
       assert_equal(JSI::JSON::Pointer.new(['a', 'b']), sub.jsi_ptr)
-      parent = sub.parent_node
+      parent = sub.jsi_parent_node
       assert_equal(JSI::JSON::Pointer.new(['a']), parent.jsi_ptr)
       assert_equal({'b' => []}, parent.node_content)
       assert_equal(node['a'], parent)
-      root_from_sub = sub.parent_node.parent_node
+      root_from_sub = sub.jsi_parent_node.jsi_parent_node
       assert_equal(JSI::JSON::Pointer.new([]), root_from_sub.jsi_ptr)
       assert_equal({'a' => {'b' => []}}, root_from_sub.node_content)
       assert_equal(node, root_from_sub)
       err = assert_raises(JSI::JSON::Pointer::ReferenceError) do
-        root_from_sub.parent_node
+        root_from_sub.jsi_parent_node
       end
       assert_equal('cannot access parent of root pointer: JSI::JSON::Pointer[]', err.message)
     end
@@ -185,8 +185,8 @@ describe JSI::JSON::Node do
       # but different object
       refute_equal(node.object_id, modified_dup.object_id)
       # the parents, obviously, are different
-      refute_equal(node.parent_node.node_content.object_id, modified_dup.parent_node.node_content.object_id)
-      refute_equal(node.parent_node.parent_node.node_content.object_id, modified_dup.parent_node.parent_node.node_content.object_id)
+      refute_equal(node.jsi_parent_node.node_content.object_id, modified_dup.jsi_parent_node.node_content.object_id)
+      refute_equal(node.jsi_parent_node.jsi_parent_node.node_content.object_id, modified_dup.jsi_parent_node.jsi_parent_node.node_content.object_id)
       # but any untouched part(s) - in this case the ['b', 'q'] at jsi_document[0] - are untouched
       assert_equal(node.jsi_root_node[0].node_content.object_id, modified_dup.jsi_root_node[0].node_content.object_id)
     end
@@ -196,8 +196,8 @@ describe JSI::JSON::Node do
       # same object, since the block just returned it
       refute_equal(node.object_id, unmodified_dup.object_id)
       # the parents are unchanged since the object is the same
-      assert_equal(node.parent_node.node_content.object_id, unmodified_dup.parent_node.node_content.object_id)
-      assert_equal(node.parent_node.parent_node.node_content.object_id, unmodified_dup.parent_node.parent_node.node_content.object_id)
+      assert_equal(node.jsi_parent_node.node_content.object_id, unmodified_dup.jsi_parent_node.node_content.object_id)
+      assert_equal(node.jsi_parent_node.jsi_parent_node.node_content.object_id, unmodified_dup.jsi_parent_node.jsi_parent_node.node_content.object_id)
       # same as the other: any untouched part(s) - in this case the ['b', 'q'] at jsi_document[0] - are untouched
       assert_equal(node.jsi_root_node[0].node_content.object_id, unmodified_dup.jsi_root_node[0].node_content.object_id)
     end

--- a/test/jsi_json_node_test.rb
+++ b/test/jsi_json_node_test.rb
@@ -43,12 +43,12 @@ describe JSI::JSON::Node do
       assert_instance_of(JSI::JSON::Pointer, JSI::JSON::Node.new({}, jsi_ptr).jsi_ptr)
     end
   end
-  describe '#node_content' do
-    it 'returns the node_content at the root' do
-      assert_equal({'a' => 'b'}, JSI::JSON::Node.new({'a' => 'b'}, jsi_ptr).node_content)
+  describe '#jsi_node_content' do
+    it 'returns the jsi_node_content at the root' do
+      assert_equal({'a' => 'b'}, JSI::JSON::Node.new({'a' => 'b'}, jsi_ptr).jsi_node_content)
     end
-    it 'returns the node_content from the deep' do
-      assert_equal('b', JSI::JSON::Node.new([0, {'x' => [{'a' => ['b']}]}], JSI::JSON::Pointer.new([1, 'x', 0, 'a', 0])).node_content)
+    it 'returns the jsi_node_content from the deep' do
+      assert_equal('b', JSI::JSON::Node.new([0, {'x' => [{'a' => ['b']}]}], JSI::JSON::Pointer.new([1, 'x', 0, 'a', 0])).jsi_node_content)
     end
   end
   describe '#deref' do
@@ -59,10 +59,10 @@ describe JSI::JSON::Node do
       }
     end
     it 'follows a $ref' do
-      assert_equal({'bar' => ['baz']}, node['a'].deref.node_content)
+      assert_equal({'bar' => ['baz']}, node['a'].deref.jsi_node_content)
     end
     it 'returns the node when there is no $ref to follow' do
-      assert_equal({'bar' => ['baz']}, node['foo'].deref.node_content)
+      assert_equal({'bar' => ['baz']}, node['foo'].deref.jsi_node_content)
     end
     describe "dealing with google's invalid $refs" do
       let(:jsi_document) do
@@ -73,11 +73,11 @@ describe JSI::JSON::Node do
       end
       it 'subscripts a node consisting of a $ref WITHOUT following' do
         subscripted = node['a']
-        assert_equal({'$ref' => 'bar', 'foo' => 'bar'}, subscripted.node_content)
+        assert_equal({'$ref' => 'bar', 'foo' => 'bar'}, subscripted.jsi_node_content)
         assert_equal(JSI::JSON::Pointer.new(['a']), subscripted.jsi_ptr)
       end
       it 'looks for a node in #/schemas with the name of the $ref' do
-        assert_equal({'description' => ['baz']}, node['a'].deref.node_content)
+        assert_equal({'description' => ['baz']}, node['a'].deref.jsi_node_content)
       end
     end
     describe "dealing with whatever this is" do
@@ -89,7 +89,7 @@ describe JSI::JSON::Node do
         }
       end
       it 'looks for a node in #/schemas with the name of the $ref' do
-        assert_equal({'id' => 'BarID', 'description' => 'baz'}, node['a'].deref.node_content)
+        assert_equal({'id' => 'BarID', 'description' => 'baz'}, node['a'].deref.jsi_node_content)
       end
     end
   end
@@ -102,16 +102,16 @@ describe JSI::JSON::Node do
       it 'returns ArrayNode for an array' do
         subscripted = node[1]['x']
         assert_instance_of(JSI::JSON::ArrayNode, subscripted)
-        assert_equal([{'a' => ['b']}], subscripted.node_content)
+        assert_equal([{'a' => ['b']}], subscripted.jsi_node_content)
         assert_equal(JSI::JSON::Pointer.new([1, 'x']), subscripted.jsi_ptr)
       end
       it 'returns HashNode for a Hash' do
         subscripted = node[1]
         assert_instance_of(JSI::JSON::HashNode, subscripted)
-        assert_equal({'x' => [{'a' => ['b']}]}, subscripted.node_content)
+        assert_equal({'x' => [{'a' => ['b']}]}, subscripted.jsi_node_content)
         assert_equal(JSI::JSON::Pointer.new([1]), subscripted.jsi_ptr)
       end
-      describe 'node_content does not respond to []' do
+      describe 'jsi_node_content does not respond to []' do
         let(:jsi_document) { Object.new }
         it 'cannot subscript' do
           err = assert_raises(NoMethodError) { node['x'] }
@@ -128,7 +128,7 @@ describe JSI::JSON::Node do
       end
       it 'subscripts a node consisting of a $ref without following' do
         subscripted = node['a']
-        assert_equal({'$ref' => '#/foo', 'description' => 'hi'}, subscripted.node_content)
+        assert_equal({'$ref' => '#/foo', 'description' => 'hi'}, subscripted.jsi_node_content)
         assert_equal(JSI::JSON::Pointer.new(['a']), subscripted.jsi_ptr)
       end
     end
@@ -151,8 +151,8 @@ describe JSI::JSON::Node do
   end
   describe '#jsi_root_node' do
     let(:jsi_document) { {'a' => {'b' => 3}} }
-    it 'has node_content that is the jsi_document' do
-      assert_equal({'a' => {'b' => 3}}, node['a'].jsi_root_node.node_content)
+    it 'has jsi_node_content that is the jsi_document' do
+      assert_equal({'a' => {'b' => 3}}, node['a'].jsi_root_node.jsi_node_content)
     end
   end
   describe '#jsi_parent_node' do
@@ -162,11 +162,11 @@ describe JSI::JSON::Node do
       assert_equal(JSI::JSON::Pointer.new(['a', 'b']), sub.jsi_ptr)
       parent = sub.jsi_parent_node
       assert_equal(JSI::JSON::Pointer.new(['a']), parent.jsi_ptr)
-      assert_equal({'b' => []}, parent.node_content)
+      assert_equal({'b' => []}, parent.jsi_node_content)
       assert_equal(node['a'], parent)
       root_from_sub = sub.jsi_parent_node.jsi_parent_node
       assert_equal(JSI::JSON::Pointer.new([]), root_from_sub.jsi_ptr)
-      assert_equal({'a' => {'b' => []}}, root_from_sub.node_content)
+      assert_equal({'a' => {'b' => []}}, root_from_sub.jsi_node_content)
       assert_equal(node, root_from_sub)
       err = assert_raises(JSI::JSON::Pointer::ReferenceError) do
         root_from_sub.jsi_parent_node
@@ -185,10 +185,10 @@ describe JSI::JSON::Node do
       # but different object
       refute_equal(node.object_id, modified_dup.object_id)
       # the parents, obviously, are different
-      refute_equal(node.jsi_parent_node.node_content.object_id, modified_dup.jsi_parent_node.node_content.object_id)
-      refute_equal(node.jsi_parent_node.jsi_parent_node.node_content.object_id, modified_dup.jsi_parent_node.jsi_parent_node.node_content.object_id)
+      refute_equal(node.jsi_parent_node.jsi_node_content.object_id, modified_dup.jsi_parent_node.jsi_node_content.object_id)
+      refute_equal(node.jsi_parent_node.jsi_parent_node.jsi_node_content.object_id, modified_dup.jsi_parent_node.jsi_parent_node.jsi_node_content.object_id)
       # but any untouched part(s) - in this case the ['b', 'q'] at jsi_document[0] - are untouched
-      assert_equal(node.jsi_root_node[0].node_content.object_id, modified_dup.jsi_root_node[0].node_content.object_id)
+      assert_equal(node.jsi_root_node[0].jsi_node_content.object_id, modified_dup.jsi_root_node[0].jsi_node_content.object_id)
     end
     it 'returns the same object' do
       unmodified_dup = node.modified_copy { |o| o }
@@ -196,10 +196,10 @@ describe JSI::JSON::Node do
       # same object, since the block just returned it
       refute_equal(node.object_id, unmodified_dup.object_id)
       # the parents are unchanged since the object is the same
-      assert_equal(node.jsi_parent_node.node_content.object_id, unmodified_dup.jsi_parent_node.node_content.object_id)
-      assert_equal(node.jsi_parent_node.jsi_parent_node.node_content.object_id, unmodified_dup.jsi_parent_node.jsi_parent_node.node_content.object_id)
+      assert_equal(node.jsi_parent_node.jsi_node_content.object_id, unmodified_dup.jsi_parent_node.jsi_node_content.object_id)
+      assert_equal(node.jsi_parent_node.jsi_parent_node.jsi_node_content.object_id, unmodified_dup.jsi_parent_node.jsi_parent_node.jsi_node_content.object_id)
       # same as the other: any untouched part(s) - in this case the ['b', 'q'] at jsi_document[0] - are untouched
-      assert_equal(node.jsi_root_node[0].node_content.object_id, unmodified_dup.jsi_root_node[0].node_content.object_id)
+      assert_equal(node.jsi_root_node[0].jsi_node_content.object_id, unmodified_dup.jsi_root_node[0].jsi_node_content.object_id)
     end
     it 'raises subscripting string from array' do
       err = assert_raises(TypeError) { JSI::JSON::Node.new(jsi_document, JSI::JSON::Pointer.new(['x'])).modified_copy(&:dup) }

--- a/test/jsi_json_node_test.rb
+++ b/test/jsi_json_node_test.rb
@@ -2,57 +2,57 @@ require_relative 'test_helper'
 
 describe JSI::JSON::Node do
   let(:path) { [] }
-  let(:node_ptr) { JSI::JSON::Pointer.new(path) }
-  let(:node) { JSI::JSON::Node.new(node_document, node_ptr) }
+  let(:jsi_ptr) { JSI::JSON::Pointer.new(path) }
+  let(:node) { JSI::JSON::Node.new(jsi_document, jsi_ptr) }
 
   describe 'initialization' do
     it 'initializes' do
-      node = JSI::JSON::Node.new({'a' => 'b'}, node_ptr)
-      assert_equal({'a' => 'b'}, node.node_document)
-      assert_equal(JSI::JSON::Pointer.new([]), node.node_ptr)
+      node = JSI::JSON::Node.new({'a' => 'b'}, jsi_ptr)
+      assert_equal({'a' => 'b'}, node.jsi_document)
+      assert_equal(JSI::JSON::Pointer.new([]), node.jsi_ptr)
     end
-    it 'initializes, node_ptr is not node_ptr' do
+    it 'initializes, jsi_ptr is not jsi_ptr' do
       err = assert_raises(TypeError) { JSI::JSON::Node.new({'a' => 'b'}, []) }
-      assert_equal('node_ptr must be a JSI::JSON::Pointer. got: [] (Array)', err.message)
+      assert_equal('jsi_ptr must be a JSI::JSON::Pointer. got: [] (Array)', err.message)
     end
-    it 'initializes, node_document is another Node' do
-      err = assert_raises(TypeError) { JSI::JSON::Node.new(JSI::JSON::Node.new({'a' => 'b'}, node_ptr), node_ptr) }
-      assert_equal("node_document of a Node should not be another JSI::JSON::Node: #<JSI::JSON::Node # {\"a\"=>\"b\"}>", err.message)
+    it 'initializes, jsi_document is another Node' do
+      err = assert_raises(TypeError) { JSI::JSON::Node.new(JSI::JSON::Node.new({'a' => 'b'}, jsi_ptr), jsi_ptr) }
+      assert_equal("jsi_document of a Node should not be another JSI::JSON::Node: #<JSI::JSON::Node # {\"a\"=>\"b\"}>", err.message)
     end
   end
   describe 'initialization by .new_by_type' do
     it 'initializes HashNode' do
       node = JSI::JSON::Node.new_doc({'a' => 'b'})
       assert_instance_of(JSI::JSON::HashNode, node)
-      assert_equal({'a' => 'b'}, node.node_document)
+      assert_equal({'a' => 'b'}, node.jsi_document)
     end
     it 'initializes ArrayNode' do
       node = JSI::JSON::Node.new_doc(['a', 'b'])
       assert_instance_of(JSI::JSON::ArrayNode, node)
-      assert_equal(['a', 'b'], node.node_document)
+      assert_equal(['a', 'b'], node.jsi_document)
     end
     it 'initializes Node' do
       object = Object.new
       node = JSI::JSON::Node.new_doc(object)
       assert_instance_of(JSI::JSON::Node, node)
-      assert_equal(object, node.node_document)
+      assert_equal(object, node.jsi_document)
     end
   end
-  describe '#node_ptr' do
+  describe '#jsi_ptr' do
     it 'is a JSI::JSON::Pointer' do
-      assert_instance_of(JSI::JSON::Pointer, JSI::JSON::Node.new({}, node_ptr).node_ptr)
+      assert_instance_of(JSI::JSON::Pointer, JSI::JSON::Node.new({}, jsi_ptr).jsi_ptr)
     end
   end
   describe '#node_content' do
     it 'returns the node_content at the root' do
-      assert_equal({'a' => 'b'}, JSI::JSON::Node.new({'a' => 'b'}, node_ptr).node_content)
+      assert_equal({'a' => 'b'}, JSI::JSON::Node.new({'a' => 'b'}, jsi_ptr).node_content)
     end
     it 'returns the node_content from the deep' do
       assert_equal('b', JSI::JSON::Node.new([0, {'x' => [{'a' => ['b']}]}], JSI::JSON::Pointer.new([1, 'x', 0, 'a', 0])).node_content)
     end
   end
   describe '#deref' do
-    let(:node_document) do
+    let(:jsi_document) do
       {
         'foo' => {'bar' => ['baz']},
         'a' => {'$ref' => '#/foo'},
@@ -65,7 +65,7 @@ describe JSI::JSON::Node do
       assert_equal({'bar' => ['baz']}, node['foo'].deref.node_content)
     end
     describe "dealing with google's invalid $refs" do
-      let(:node_document) do
+      let(:jsi_document) do
         {
           'schemas' => {'bar' => {'description' => ['baz']}},
           'a' => {'$ref' => 'bar', 'foo' => 'bar'},
@@ -74,7 +74,7 @@ describe JSI::JSON::Node do
       it 'subscripts a node consisting of a $ref WITHOUT following' do
         subscripted = node['a']
         assert_equal({'$ref' => 'bar', 'foo' => 'bar'}, subscripted.node_content)
-        assert_equal(JSI::JSON::Pointer.new(['a']), subscripted.node_ptr)
+        assert_equal(JSI::JSON::Pointer.new(['a']), subscripted.jsi_ptr)
       end
       it 'looks for a node in #/schemas with the name of the $ref' do
         assert_equal({'description' => ['baz']}, node['a'].deref.node_content)
@@ -82,7 +82,7 @@ describe JSI::JSON::Node do
     end
     describe "dealing with whatever this is" do
       # I think google uses this style in some cases maybe. I don't remember.
-      let(:node_document) do
+      let(:jsi_document) do
         {
           'schemas' => {'bar' => {'id' => 'BarID', 'description' => 'baz'}},
           'a' => {'$ref' => 'BarID'},
@@ -95,7 +95,7 @@ describe JSI::JSON::Node do
   end
   describe '#[]' do
     describe 'without dereferencing' do
-      let(:node_document) { [0, {'x' => [{'a' => ['b']}]}] }
+      let(:jsi_document) { [0, {'x' => [{'a' => ['b']}]}] }
       it 'subscripts arrays and hashes' do
         assert_equal('b', node[1]['x'][0]['a'][0])
       end
@@ -103,24 +103,24 @@ describe JSI::JSON::Node do
         subscripted = node[1]['x']
         assert_instance_of(JSI::JSON::ArrayNode, subscripted)
         assert_equal([{'a' => ['b']}], subscripted.node_content)
-        assert_equal(JSI::JSON::Pointer.new([1, 'x']), subscripted.node_ptr)
+        assert_equal(JSI::JSON::Pointer.new([1, 'x']), subscripted.jsi_ptr)
       end
       it 'returns HashNode for a Hash' do
         subscripted = node[1]
         assert_instance_of(JSI::JSON::HashNode, subscripted)
         assert_equal({'x' => [{'a' => ['b']}]}, subscripted.node_content)
-        assert_equal(JSI::JSON::Pointer.new([1]), subscripted.node_ptr)
+        assert_equal(JSI::JSON::Pointer.new([1]), subscripted.jsi_ptr)
       end
       describe 'node_content does not respond to []' do
-        let(:node_document) { Object.new }
+        let(:jsi_document) { Object.new }
         it 'cannot subscript' do
           err = assert_raises(NoMethodError) { node['x'] }
-          assert_equal("undefined method `[]`\nsubscripting with \"x\" (String) from Object. content is: #{node_document.pretty_inspect.chomp}", err.message)
+          assert_equal("undefined method `[]`\nsubscripting with \"x\" (String) from Object. content is: #{jsi_document.pretty_inspect.chomp}", err.message)
         end
       end
     end
     describe 'with dereferencing' do
-      let(:node_document) do
+      let(:jsi_document) do
         {
           'foo' => {'bar' => ['baz']},
           'a' => {'$ref' => '#/foo', 'description' => 'hi'}, # not sure a description is actually allowed here, whatever
@@ -129,43 +129,43 @@ describe JSI::JSON::Node do
       it 'subscripts a node consisting of a $ref without following' do
         subscripted = node['a']
         assert_equal({'$ref' => '#/foo', 'description' => 'hi'}, subscripted.node_content)
-        assert_equal(JSI::JSON::Pointer.new(['a']), subscripted.node_ptr)
+        assert_equal(JSI::JSON::Pointer.new(['a']), subscripted.jsi_ptr)
       end
     end
   end
   describe '#[]=' do
-    let(:node_document) { [0, {'x' => [{'a' => ['b']}]}] }
+    let(:jsi_document) { [0, {'x' => [{'a' => ['b']}]}] }
     it 'assigns' do
       node[0] = 'abcdefg'
-      assert_equal(['abcdefg', {'x' => [{'a' => ['b']}]}], node_document)
-      string_node = JSI::JSON::Node.new(node_document, JSI::JSON::Pointer.new([0]))
+      assert_equal(['abcdefg', {'x' => [{'a' => ['b']}]}], jsi_document)
+      string_node = JSI::JSON::Node.new(jsi_document, JSI::JSON::Pointer.new([0]))
       string_node[0..2] = '0'
-      assert_equal(['0defg', {'x' => [{'a' => ['b']}]}], node_document)
+      assert_equal(['0defg', {'x' => [{'a' => ['b']}]}], jsi_document)
       node[0] = node[1]
-      assert_equal([{'x' => [{'a' => ['b']}]}, {'x' => [{'a' => ['b']}]}], node_document)
+      assert_equal([{'x' => [{'a' => ['b']}]}, {'x' => [{'a' => ['b']}]}], jsi_document)
     end
     it 'assigns, deeper' do
       node[1]['y'] = node[1]['x'][0]
-      assert_equal([0, {'x' => [{'a' => ['b']}], 'y' => {'a' => ['b']}}], node_document)
+      assert_equal([0, {'x' => [{'a' => ['b']}], 'y' => {'a' => ['b']}}], jsi_document)
     end
   end
   describe '#document_root_node' do
-    let(:node_document) { {'a' => {'b' => 3}} }
-    it 'has node_content that is the node_document' do
+    let(:jsi_document) { {'a' => {'b' => 3}} }
+    it 'has node_content that is the jsi_document' do
       assert_equal({'a' => {'b' => 3}}, node['a'].document_root_node.node_content)
     end
   end
   describe '#parent_node' do
-    let(:node_document) { {'a' => {'b' => []}} }
+    let(:jsi_document) { {'a' => {'b' => []}} }
     it 'finds a parent' do
       sub = node['a']['b']
-      assert_equal(JSI::JSON::Pointer.new(['a', 'b']), sub.node_ptr)
+      assert_equal(JSI::JSON::Pointer.new(['a', 'b']), sub.jsi_ptr)
       parent = sub.parent_node
-      assert_equal(JSI::JSON::Pointer.new(['a']), parent.node_ptr)
+      assert_equal(JSI::JSON::Pointer.new(['a']), parent.jsi_ptr)
       assert_equal({'b' => []}, parent.node_content)
       assert_equal(node['a'], parent)
       root_from_sub = sub.parent_node.parent_node
-      assert_equal(JSI::JSON::Pointer.new([]), root_from_sub.node_ptr)
+      assert_equal(JSI::JSON::Pointer.new([]), root_from_sub.jsi_ptr)
       assert_equal({'a' => {'b' => []}}, root_from_sub.node_content)
       assert_equal(node, root_from_sub)
       err = assert_raises(JSI::JSON::Pointer::ReferenceError) do
@@ -175,7 +175,7 @@ describe JSI::JSON::Node do
     end
   end
   describe '#modified_copy' do
-    let(:node_document) { [['b', 'q'], {'c' => ['d', 'e']}] }
+    let(:jsi_document) { [['b', 'q'], {'c' => ['d', 'e']}] }
     let(:path) { ['1', 'c'] }
     it 'returns a different object' do
       # simplest thing
@@ -187,7 +187,7 @@ describe JSI::JSON::Node do
       # the parents, obviously, are different
       refute_equal(node.parent_node.node_content.object_id, modified_dup.parent_node.node_content.object_id)
       refute_equal(node.parent_node.parent_node.node_content.object_id, modified_dup.parent_node.parent_node.node_content.object_id)
-      # but any untouched part(s) - in this case the ['b', 'q'] at node_document[0] - are untouched
+      # but any untouched part(s) - in this case the ['b', 'q'] at jsi_document[0] - are untouched
       assert_equal(node.document_root_node[0].node_content.object_id, modified_dup.document_root_node[0].node_content.object_id)
     end
     it 'returns the same object' do
@@ -198,58 +198,58 @@ describe JSI::JSON::Node do
       # the parents are unchanged since the object is the same
       assert_equal(node.parent_node.node_content.object_id, unmodified_dup.parent_node.node_content.object_id)
       assert_equal(node.parent_node.parent_node.node_content.object_id, unmodified_dup.parent_node.parent_node.node_content.object_id)
-      # same as the other: any untouched part(s) - in this case the ['b', 'q'] at node_document[0] - are untouched
+      # same as the other: any untouched part(s) - in this case the ['b', 'q'] at jsi_document[0] - are untouched
       assert_equal(node.document_root_node[0].node_content.object_id, unmodified_dup.document_root_node[0].node_content.object_id)
     end
     it 'raises subscripting string from array' do
-      err = assert_raises(TypeError) { JSI::JSON::Node.new(node_document, JSI::JSON::Pointer.new(['x'])).modified_copy(&:dup) }
+      err = assert_raises(TypeError) { JSI::JSON::Node.new(jsi_document, JSI::JSON::Pointer.new(['x'])).modified_copy(&:dup) }
       assert_match(%r(\Abad subscript "x" with remaining subpath: \[\] for array: \[.*\]\z)m, err.message)
     end
     it 'raises subscripting from invalid subpath' do
-      err = assert_raises(TypeError) { JSI::JSON::Node.new(node_document, JSI::JSON::Pointer.new([0, 0, 'what'])).modified_copy(&:dup) }
+      err = assert_raises(TypeError) { JSI::JSON::Node.new(jsi_document, JSI::JSON::Pointer.new([0, 0, 'what'])).modified_copy(&:dup) }
       assert_match(%r(bad subscript: "what" with remaining subpath: \[\] for content: "b"\z)m, err.message)
     end
   end
   describe '#inspect' do
-    let(:node_document) { {'a' => {'c' => ['d', 'e']}} }
+    let(:jsi_document) { {'a' => {'c' => ['d', 'e']}} }
     let(:path) { ['a'] }
     it 'inspects' do
       assert_equal(%Q(#<JSI::JSON::Node #/a {"c"=>["d", "e"]}>), node.inspect)
     end
   end
   describe '#pretty_print' do
-    let(:node_document) { {'a' => {'c' => ['d', 'e']}} }
+    let(:jsi_document) { {'a' => {'c' => ['d', 'e']}} }
     let(:path) { ['a'] }
     it 'pretty prints' do
       assert_equal(%Q(#<JSI::JSON::Node #/a {"c"=>["d", "e"]}>), node.pretty_inspect.chomp)
     end
   end
   describe '#jsi_fingerprint' do
-    let(:node_ptr) { JSI::JSON::Pointer.new([]) }
+    let(:jsi_ptr) { JSI::JSON::Pointer.new([]) }
     it 'hashes consistently' do
-      assert_equal('x', {JSI::JSON::Node.new([0], node_ptr) => 'x'}[JSI::JSON::Node.new([0], node_ptr)])
+      assert_equal('x', {JSI::JSON::Node.new([0], jsi_ptr) => 'x'}[JSI::JSON::Node.new([0], jsi_ptr)])
     end
     it 'hashes consistently regardless of the Node being decorated as a subclass' do
-      assert_equal('x', {JSI::JSON::Node.new_doc([0]) => 'x'}[JSI::JSON::Node.new([0], node_ptr)])
-      assert_equal('x', {JSI::JSON::Node.new([0], node_ptr) => 'x'}[JSI::JSON::Node.new_doc([0])])
+      assert_equal('x', {JSI::JSON::Node.new_doc([0]) => 'x'}[JSI::JSON::Node.new([0], jsi_ptr)])
+      assert_equal('x', {JSI::JSON::Node.new([0], jsi_ptr) => 'x'}[JSI::JSON::Node.new_doc([0])])
     end
     it '==' do
-      assert_equal(JSI::JSON::Node.new([0], node_ptr), JSI::JSON::Node.new([0], node_ptr))
-      assert_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new([0], node_ptr))
-      assert_equal(JSI::JSON::Node.new([0], node_ptr), JSI::JSON::Node.new_doc([0]))
+      assert_equal(JSI::JSON::Node.new([0], jsi_ptr), JSI::JSON::Node.new([0], jsi_ptr))
+      assert_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new([0], jsi_ptr))
+      assert_equal(JSI::JSON::Node.new([0], jsi_ptr), JSI::JSON::Node.new_doc([0]))
       assert_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new_doc([0]))
     end
     it '!=' do
-      refute_equal(JSI::JSON::Node.new([0], node_ptr), JSI::JSON::Node.new({}, node_ptr))
-      refute_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new({}, node_ptr))
-      refute_equal(JSI::JSON::Node.new([0], node_ptr), JSI::JSON::Node.new_doc({}))
+      refute_equal(JSI::JSON::Node.new([0], jsi_ptr), JSI::JSON::Node.new({}, jsi_ptr))
+      refute_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new({}, jsi_ptr))
+      refute_equal(JSI::JSON::Node.new([0], jsi_ptr), JSI::JSON::Node.new_doc({}))
       refute_equal(JSI::JSON::Node.new_doc([0]), JSI::JSON::Node.new_doc({}))
       refute_equal({}, JSI::JSON::Node.new_doc({}))
       refute_equal(JSI::JSON::Node.new_doc({}), {})
     end
   end
   describe '#as_json' do
-    let(:node_document) { {'a' => 'b'} }
+    let(:jsi_document) { {'a' => 'b'} }
     it '#as_json' do
       assert_equal({'a' => 'b'}, node.as_json)
     end

--- a/test/metaschema_node_test.rb
+++ b/test/metaschema_node_test.rb
@@ -1,11 +1,11 @@
 require_relative 'test_helper'
 
 describe JSI::MetaschemaNode do
-  let(:node_document) { {'properties' => {'properties' => {'additionalProperties' => {'$ref' => '#'}}}} }
-  let(:node_ptr) { JSI::JSON::Pointer[] }
+  let(:jsi_document) { {'properties' => {'properties' => {'additionalProperties' => {'$ref' => '#'}}}} }
+  let(:jsi_ptr) { JSI::JSON::Pointer[] }
   let(:metaschema_root_ptr) { JSI::JSON::Pointer[] }
   let(:root_schema_ptr) { JSI::JSON::Pointer[] }
-  let(:subject) { JSI::MetaschemaNode.new(node_document, node_ptr: node_ptr, metaschema_root_ptr: node_ptr, root_schema_ptr: node_ptr) }
+  let(:subject) { JSI::MetaschemaNode.new(jsi_document, jsi_ptr: jsi_ptr, metaschema_root_ptr: jsi_ptr, root_schema_ptr: jsi_ptr) }
   describe 'initialization' do
     it 'initializes' do
       subject


### PR DESCRIPTION
fix some names. prefix some things with `jsi_` to reduce collisions for accessors on Base. change some references to 'node' that weren't very meaningful.