### PR TITLE
SchemaAncestorNode extends Base with #jsi_subschema_base_uri, #jsi_subschema_resource_ancestors, #schema_absolute_uri

### DIFF
--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -13,6 +13,7 @@ module JSI
     include Util::Memoize
     include Enumerable
     include PathedNode
+    include Schema::SchemaAncestorNode
 
     # an exception raised when #[] is invoked on an instance which is not an array or hash
     class CannotSubscriptError < StandardError

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -261,6 +261,8 @@ module JSI
               jsi_document: @jsi_document,
               jsi_ptr: @jsi_ptr[token],
               jsi_root_node: @jsi_root_node,
+              jsi_schema_base_uri: is_a?(Schema) ? jsi_subschema_base_uri : jsi_schema_base_uri,
+              jsi_schema_resource_ancestors: is_a?(Schema) ? jsi_subschema_resource_ancestors : jsi_schema_resource_ancestors,
             )
           else
             value

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -131,7 +131,9 @@ module JSI
     def initialize(instance,
         jsi_document: nil,
         jsi_ptr: nil,
-        jsi_root_node: nil
+        jsi_root_node: nil,
+        jsi_schema_base_uri: nil,
+        jsi_schema_resource_ancestors: []
     )
       unless respond_to?(:jsi_schemas)
         raise(TypeError, "cannot instantiate #{self.class.inspect} which has no method #jsi_schemas. it is recommended to instantiate JSIs from a schema using JSI::Schema#new_jsi.")
@@ -167,6 +169,9 @@ module JSI
         @jsi_ptr = JSI::JSON::Pointer[]
         @jsi_root_node = self
       end
+
+      self.jsi_schema_base_uri = jsi_schema_base_uri
+      self.jsi_schema_resource_ancestors = jsi_schema_resource_ancestors
 
       if self.jsi_instance.respond_to?(:to_hash)
         extend PathedHashNode
@@ -333,6 +338,8 @@ module JSI
         self.class.new(Base::NOINSTANCE,
           jsi_document: modified_document,
           jsi_ptr: @jsi_ptr,
+          jsi_schema_base_uri: @jsi_schema_base_uri,
+          jsi_schema_resource_ancestors: @jsi_schema_resource_ancestors, # this can only be empty but included for consistency
         )
       else
         modified_jsi_root_node = @jsi_root_node.jsi_modified_copy do |root|

--- a/lib/jsi/metaschema_node.rb
+++ b/lib/jsi/metaschema_node.rb
@@ -139,7 +139,13 @@ module JSI
 
     # @return [MetaschemaNode] document root MetaschemaNode
     def jsi_root_node
-      new_node(jsi_ptr: JSI::JSON::Pointer[])
+      if jsi_ptr.root?
+        self
+      else
+        new_node(
+          jsi_ptr: JSI::JSON::Pointer[],
+        )
+      end
     end
 
     # @return [MetaschemaNode] parent MetaschemaNode

--- a/lib/jsi/metaschema_node.rb
+++ b/lib/jsi/metaschema_node.rb
@@ -26,6 +26,7 @@ module JSI
     autoload :BootstrapSchema, 'jsi/metaschema_node/bootstrap_schema'
 
     include PathedNode
+    include Schema::SchemaAncestorNode
     include Util::Memoize
 
     # not every MetaschemaNode is actually an Enumerable, but it's better to include Enumerable on

--- a/lib/jsi/metaschema_node/bootstrap_schema.rb
+++ b/lib/jsi/metaschema_node/bootstrap_schema.rb
@@ -10,6 +10,7 @@ module JSI
   class MetaschemaNode::BootstrapSchema
     include Util::Memoize
     include Util::FingerprintHash
+    include Schema::SchemaAncestorNode
 
     class << self
       def inspect

--- a/lib/jsi/metaschema_node/bootstrap_schema.rb
+++ b/lib/jsi/metaschema_node/bootstrap_schema.rb
@@ -4,6 +4,11 @@ module JSI
   # @private
   # internal class to bootstrap a metaschema. represents a schema without the complexity of JSI::Base. the
   # schema is represented but schemas describing the schema are not.
+  #
+  # this class is to only be instantiated on nodes in the document that are known to be schemas.
+  # Schema#subschema and Schema#resource_root_subschema are the intended mechanisms to instantiate subschemas
+  # and resolve references. #[] and #jsi_root_node are not implemented.
+  #
   # metaschema instance modules are attached to generated subclasses of BootstrapSchema by
   # {SchemaClasses.bootstrap_schema_class}. that subclass is instantiated with a document and
   # pointer, representing a schema.

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -235,7 +235,13 @@ module JSI
     def resource_root_subschema(ptr)
       begin
         schema = self
-        if schema.is_a?(MetaschemaNode::BootstrapSchema)
+        if schema.schema_resource_root?
+          result_schema = schema.subschema(ptr)
+        elsif schema.is_a?(MetaschemaNode::BootstrapSchema)
+          # BootstrapSchema does not track jsi_schema_resource_ancestors used by #schema_resource_root;
+          # resource_root_subschema is always relative to the document root.
+          # BootstrapSchema also does not implement jsi_root_node or #[]. we instantiate the ptr directly
+          # rather than as a subschema from the root.
           result_schema = schema.class.new(
             schema.jsi_document,
             jsi_ptr: ptr,

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -189,9 +189,22 @@ module JSI
       @jsi_schema_instance_modules = jsi_schema_instance_modules
     end
 
+    # a resource containing this schema.
+    #
+    # if any parent, or this schema itself, is a schema with an absolute uri (see #schema_absolute_uri),
+    # the resource root is the closest schema with an absolute uri.
+    #
+    # if no parent schema has an absolute uri, the schema_resource_root is the root of the document
+    # (our #jsi_root_node). in this case, the resource root may or may not be a schema itself.
+    #
     # @return [JSI::Base] resource containing this schema
     def schema_resource_root
-      jsi_root_node # TODO
+      jsi_subschema_resource_ancestors.reverse_each.detect(&:schema_resource_root?) || jsi_root_node
+    end
+
+    # @return [Boolean] is this schema the root of a schema resource?
+    def schema_resource_root?
+      jsi_ptr.root? || !!schema_absolute_uri
     end
 
     # returns a subschema of this Schema

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -6,6 +6,8 @@ module JSI
   # the content of an instance which is a JSI::Schema (referred to in this context as schema_content) is
   # expected to be a Hash (JSON object) or a Boolean.
   module Schema
+    autoload :SchemaAncestorNode, 'jsi/schema/schema_ancestor_node'
+
     class Error < StandardError
     end
 

--- a/lib/jsi/schema/schema_ancestor_node.rb
+++ b/lib/jsi/schema/schema_ancestor_node.rb
@@ -3,5 +3,35 @@ module JSI
   # a node in a document which may contain a schema somewhere within is extended with SchemaAncestorNode, for
   # tracking things necessary for a schema to function correctly
   module Schema::SchemaAncestorNode
+    # @private
+    # @return [Addressable::URI, nil] the base URI used to resolve the ids of schemas at or below this JSI.
+    #   this is always an absolute URI (with no fragment).
+    #   this may be the absolute schema URI of a parent schema or the URI from which the document was retrieved.
+    attr_reader :jsi_schema_base_uri
+
+    # @private
+    # @return [Array<JSI::Schema>] schema resources which are ancestors of this JSI.
+    #   this does not include self.
+    attr_reader :jsi_schema_resource_ancestors
+
+    private
+
+    def jsi_schema_base_uri=(jsi_schema_base_uri)
+      if jsi_schema_base_uri
+        unless jsi_schema_base_uri.respond_to?(:to_str)
+          raise(TypeError, "jsi_schema_base_uri must be string or Addressable::URI; got: #{jsi_schema_base_uri.inspect}")
+        end
+        @jsi_schema_base_uri = Addressable::URI.parse(jsi_schema_base_uri).freeze
+        unless @jsi_schema_base_uri.absolute? && !@jsi_schema_base_uri.fragment
+          raise(ArgumentError, "jsi_schema_base_uri must be an absolute URI with no fragment; got: #{jsi_schema_base_uri.inspect}")
+        end
+      else
+        @jsi_schema_base_uri = nil
+      end
+    end
+
+    def jsi_schema_resource_ancestors=(jsi_schema_resource_ancestors)
+      @jsi_schema_resource_ancestors = jsi_schema_resource_ancestors
+    end
   end
 end

--- a/lib/jsi/schema/schema_ancestor_node.rb
+++ b/lib/jsi/schema/schema_ancestor_node.rb
@@ -34,7 +34,31 @@ module JSI
     end
 
     def jsi_schema_resource_ancestors=(jsi_schema_resource_ancestors)
-      @jsi_schema_resource_ancestors = jsi_schema_resource_ancestors
+      if jsi_schema_resource_ancestors
+        unless jsi_schema_resource_ancestors.respond_to?(:to_ary)
+          raise(TypeError, "jsi_schema_resource_ancestors must be an array; got: #{jsi_schema_resource_ancestors.inspect}")
+        end
+        # sanity check the ancestors are in order
+        last_anc_ptr = nil
+        jsi_schema_resource_ancestors.each do |anc|
+          if last_anc_ptr.nil?
+            # pass
+          elsif last_anc_ptr == anc.jsi_ptr
+            raise(Bug, "duplicate ancestors in #{jsi_schema_resource_ancestors.pretty_inspect}")
+          elsif !last_anc_ptr.contains?(anc.jsi_ptr)
+            raise(Bug, "ancestor ptr #{anc.jsi_ptr} not contained by previous: #{last_anc_ptr} in #{jsi_schema_resource_ancestors.pretty_inspect}")
+          end
+          if anc.jsi_ptr == jsi_ptr
+            raise(Bug, "ancestor is self")
+          elsif !anc.jsi_ptr.contains?(jsi_ptr)
+            raise(Bug, "ancestor does not contain self")
+          end
+        end
+
+        @jsi_schema_resource_ancestors = jsi_schema_resource_ancestors.to_ary.freeze
+      else
+        @jsi_schema_resource_ancestors = [].freeze
+      end
     end
   end
 end

--- a/lib/jsi/schema/schema_ancestor_node.rb
+++ b/lib/jsi/schema/schema_ancestor_node.rb
@@ -38,6 +38,9 @@ module JSI
         unless jsi_schema_resource_ancestors.respond_to?(:to_ary)
           raise(TypeError, "jsi_schema_resource_ancestors must be an array; got: #{jsi_schema_resource_ancestors.inspect}")
         end
+        unless jsi_schema_resource_ancestors.all? { |a| a.is_a?(Schema) }
+          raise(Schema::NotASchemaError, "jsi_schema_resource_ancestors are not all schemas")
+        end
         # sanity check the ancestors are in order
         last_anc_ptr = nil
         jsi_schema_resource_ancestors.each do |anc|

--- a/lib/jsi/schema/schema_ancestor_node.rb
+++ b/lib/jsi/schema/schema_ancestor_node.rb
@@ -1,0 +1,7 @@
+module JSI
+  # @private
+  # a node in a document which may contain a schema somewhere within is extended with SchemaAncestorNode, for
+  # tracking things necessary for a schema to function correctly
+  module Schema::SchemaAncestorNode
+  end
+end

--- a/lib/jsi/schema/schema_ancestor_node.rb
+++ b/lib/jsi/schema/schema_ancestor_node.rb
@@ -12,7 +12,10 @@ module JSI
     # @private
     # @return [Array<JSI::Schema>] schema resources which are ancestors of this JSI.
     #   this does not include self.
-    attr_reader :jsi_schema_resource_ancestors
+    def jsi_schema_resource_ancestors
+      return @jsi_schema_resource_ancestors if instance_variable_defined?(:@jsi_schema_resource_ancestors)
+      [].freeze
+    end
 
     private
 


### PR DESCRIPTION
incomplete; Schema#schema_absolute_uri  relies on not-yet-implemented #id_without_fragment