### PR TITLE
Schema#id, #id_without_fragment

### DIFF
--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -21,6 +21,30 @@ module JSI
     class NotASchemaError < Error
     end
 
+    # extends any schema which uses the keyword '$id' to identify its canonical URI
+    module BigMoneyId
+      # @return [#to_str, nil] the contents of a $id keyword whose value is a string, or nil
+      def id
+        if schema_content.respond_to?(:to_hash) && schema_content['$id'].respond_to?(:to_str)
+          schema_content['$id']
+        else
+          nil
+        end
+      end
+    end
+
+    # extends any schema which uses the keyword 'id' to identify its canonical URI
+    module OldId
+      # @return [#to_str, nil] the contents of an id keyword whose value is a string, or nil
+      def id
+        if schema_content.respond_to?(:to_hash) && schema_content['id'].respond_to?(:to_str)
+          schema_content['id']
+        else
+          nil
+        end
+      end
+    end
+
     # JSI::Schema::DescribesSchema: a schema which describes another schema. this module
     # extends a JSI::Schema instance and indicates that JSIs which instantiate the schema
     # are themselves also schemas.

--- a/lib/jsi/schema/draft04.rb
+++ b/lib/jsi/schema/draft04.rb
@@ -4,6 +4,8 @@ module JSI
   module Schema
     module Draft04
       include Schema
+      include OldId
+      include IdWithAnchor
       include Schema::Application::InplaceApplication
       include Schema::Application::ChildApplication
     end

--- a/lib/jsi/schema/draft06.rb
+++ b/lib/jsi/schema/draft06.rb
@@ -4,6 +4,8 @@ module JSI
   module Schema
     module Draft06
       include Schema
+      include BigMoneyId
+      include IdWithAnchor
       include Schema::Application::InplaceApplication
       include Schema::Application::ChildApplication
     end

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -53,6 +53,65 @@ describe JSI::Schema do
       assert_equal('https://schemas.jsi.unth.net/test/id_has_pointer#/notroot/properties/foo', subschema.schema_id)
     end
   end
+  describe '#schema_absolute_uri' do
+    describe 'draft 4' do
+      let(:metaschema) { JSI::JSONSchemaOrgDraft04 }
+      it "hasn't got one" do
+        schema = metaschema.new_schema({})
+        assert_nil(schema.schema_absolute_uri)
+      end
+      it 'uses a given id with an empty fragment' do
+        schema = metaschema.new_schema({'id' => 'http://jsi/test/schema_absolute_uri/d4/empty_fragment#'})
+        assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d4/empty_fragment'), schema.schema_absolute_uri)
+      end
+      it 'uses a given id without a fragment' do
+        schema = metaschema.new_schema({'id' => 'http://jsi/test/schema_absolute_uri/d4/given_id'})
+        assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d4/given_id'), schema.schema_absolute_uri)
+      end
+      it 'nested schema without id' do
+        schema = metaschema.new_schema({
+          'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_no_id',
+          'items' => {},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with absolute id' do
+        schema = metaschema.new_schema({
+          'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_abs_id_base',
+          'items' => {'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_abs_id'},
+        })
+        assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d4/nested_w_abs_id'), schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with relative id' do
+        schema = metaschema.new_schema({
+          'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_rel_id_base',
+          'items' => {'id' => 'nested_w_rel_id'},
+        })
+        assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d4/nested_w_rel_id'), schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with anchor id' do
+        schema = metaschema.new_schema({
+          'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_anchor_id_base',
+          'items' => {'id' => '#nested_anchor'},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with anchor id on the base' do
+        schema = metaschema.new_schema({
+          'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_anchor_on_base',
+          'items' => {'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_anchor_on_base#nested_anchor'},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with id and fragment' do
+        schema = metaschema.new_schema({
+          'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_id_frag_base',
+          'items' => {'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_id_frag#nested_anchor'},
+        })
+        assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d4/nested_w_id_frag'), schema.items.schema_absolute_uri)
+      end
+    end
+  end
   describe '#jsi_schema_module' do
     it 'returns the module for the schema' do
       schema = JSI.new_schema({'id' => 'https://schemas.jsi.unth.net/test/jsi_schema_module'})

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -131,6 +131,22 @@ describe JSI::Schema do
         })
         assert_nil(schema.items.schema_absolute_uri)
       end
+      describe 'externally supplied base uri' do
+        it 'schema with relative ids' do
+          schema = metaschema.new_schema({
+            'id' => 'root_relative',
+            'properties' => {
+              'relative' => {'id' => 'nested_relative'},
+              'absolute' => {'id' => 'http://jsi/test/d4/ignore_external_base_uri/nested_absolute'},
+              'none' => {},
+            },
+          }, base_uri: 'http://jsi/test/d4/external_base_uri/1')
+          assert_equal(Addressable::URI.parse('http://jsi/test/d4/external_base_uri/root_relative'), schema.schema_absolute_uri)
+          assert_equal(Addressable::URI.parse('http://jsi/test/d4/external_base_uri/nested_relative'), schema.properties['relative'].schema_absolute_uri)
+          assert_equal(Addressable::URI.parse('http://jsi/test/d4/ignore_external_base_uri/nested_absolute'), schema.properties['absolute'].schema_absolute_uri)
+          assert_nil(schema.properties['none'].schema_absolute_uri)
+        end
+      end
     end
     describe 'draft 6' do
       let(:metaschema) { JSI::JSONSchemaOrgDraft06 }
@@ -208,6 +224,28 @@ describe JSI::Schema do
           'items' => {'$id' => ''},
         })
         assert_nil(schema.items.schema_absolute_uri)
+      end
+      describe 'externally supplied base uri' do
+        it 'schema with relative ids' do
+          schema = metaschema.new_schema({
+            '$id' => 'root_relative',
+            'properties' => {
+              'relative' => {'$id' => 'nested_relative'},
+              'absolute' => {'$id' => 'http://jsi/test/d6/ignore_external_base_uri/nested_absolute'},
+              'none' => {},
+            },
+          }, base_uri: 'http://jsi/test/d6/external_base_uri/0')
+          assert_equal(Addressable::URI.parse('http://jsi/test/d6/external_base_uri/root_relative'), schema.schema_absolute_uri)
+          assert_equal(Addressable::URI.parse('http://jsi/test/d6/external_base_uri/nested_relative'), schema.properties['relative'].schema_absolute_uri)
+          assert_equal(Addressable::URI.parse('http://jsi/test/d6/ignore_external_base_uri/nested_absolute'), schema.properties['absolute'].schema_absolute_uri)
+          assert_nil(schema.properties['none'].schema_absolute_uri)
+        end
+      end
+    end
+    describe 'externally supplied base uri with JSI.new_schema' do
+      it 'resolves' do
+        schema = JSI.new_schema({'$id' => 'tehschema'}, base_uri: 'http://jsi/test/schema_absolute_uri/schema.new_base/0')
+        assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/schema.new_base/tehschema'), schema.schema_absolute_uri)
       end
     end
   end

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -103,6 +103,13 @@ describe JSI::Schema do
         })
         assert_nil(schema.items.schema_absolute_uri)
       end
+      it 'nested schema with anchor id on the base after resolution' do
+        schema = metaschema.new_schema({
+          'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_anchor_on_base_rel',
+          'items' => {'id' => 'nested_w_anchor_on_base_rel#nested_anchor'},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
+      end
       it 'nested schema with id and fragment' do
         schema = metaschema.new_schema({
           'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_id_frag_base',
@@ -171,6 +178,13 @@ describe JSI::Schema do
         schema = metaschema.new_schema({
           '$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_anchor_on_base',
           'items' => {'$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_anchor_on_base#nested_anchor'},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with anchor id on the base after resolution' do
+        schema = metaschema.new_schema({
+          '$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_anchor_on_base_rel',
+          'items' => {'$id' => 'nested_w_anchor_on_base_rel#nested_anchor'},
         })
         assert_nil(schema.items.schema_absolute_uri)
       end

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -110,6 +110,20 @@ describe JSI::Schema do
         })
         assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d4/nested_w_id_frag'), schema.items.schema_absolute_uri)
       end
+      it 'nested schema with id with empty fragment' do
+        schema = metaschema.new_schema({
+          'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_id_empty_frag_base',
+          'items' => {'id' => '#'},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with empty id' do
+        schema = metaschema.new_schema({
+          'id' => 'http://jsi/test/schema_absolute_uri/d4/nested_w_empty_id_base',
+          'items' => {'id' => ''},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
+      end
     end
     describe 'draft 6' do
       let(:metaschema) { JSI::JSONSchemaOrgDraft06 }
@@ -166,6 +180,20 @@ describe JSI::Schema do
           'items' => {'$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_id_frag#nested_anchor'},
         })
         assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d6/nested_w_id_frag'), schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with id with empty fragment' do
+        schema = metaschema.new_schema({
+          '$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_id_empty_frag_base',
+          'items' => {'$id' => '#'},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with empty id' do
+        schema = metaschema.new_schema({
+          '$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_empty_id_base',
+          'items' => {'$id' => ''},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
       end
     end
   end

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -111,6 +111,63 @@ describe JSI::Schema do
         assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d4/nested_w_id_frag'), schema.items.schema_absolute_uri)
       end
     end
+    describe 'draft 6' do
+      let(:metaschema) { JSI::JSONSchemaOrgDraft06 }
+      it "hasn't got one" do
+        schema = metaschema.new_schema({})
+        assert_nil(schema.schema_absolute_uri)
+      end
+      it 'uses a given id with an empty fragment' do
+        schema = metaschema.new_schema({'$id' => 'http://jsi/test/schema_absolute_uri/d6/empty_fragment#'})
+        assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d6/empty_fragment'), schema.schema_absolute_uri)
+      end
+      it 'uses a given id without a fragment' do
+        schema = metaschema.new_schema({'$id' => 'http://jsi/test/schema_absolute_uri/d6/given_id'})
+        assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d6/given_id'), schema.schema_absolute_uri)
+      end
+      it 'nested schema without id' do
+        schema = metaschema.new_schema({
+          '$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_no_id',
+          'items' => {},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with absolute id' do
+        schema = metaschema.new_schema({
+          '$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_abs_id_base',
+          'items' => {'$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_abs_id'},
+        })
+        assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d6/nested_w_abs_id'), schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with relative id' do
+        schema = metaschema.new_schema({
+          '$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_rel_id_base',
+          'items' => {'$id' => 'nested_w_rel_id'},
+        })
+        assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d6/nested_w_rel_id'), schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with anchor id' do
+        schema = metaschema.new_schema({
+          '$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_anchor_id_base',
+          'items' => {'$id' => '#nested_anchor'},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with anchor id on the base' do
+        schema = metaschema.new_schema({
+          '$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_anchor_on_base',
+          'items' => {'$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_anchor_on_base#nested_anchor'},
+        })
+        assert_nil(schema.items.schema_absolute_uri)
+      end
+      it 'nested schema with id and fragment' do
+        schema = metaschema.new_schema({
+          '$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_id_frag_base',
+          'items' => {'$id' => 'http://jsi/test/schema_absolute_uri/d6/nested_w_id_frag#nested_anchor'},
+        })
+        assert_equal(Addressable::URI.parse('http://jsi/test/schema_absolute_uri/d6/nested_w_id_frag'), schema.items.schema_absolute_uri)
+      end
+    end
   end
   describe '#jsi_schema_module' do
     it 'returns the module for the schema' do


### PR DESCRIPTION
implementing these allows Schema#schema_absolute_uri to work properly

enables schema_absolute_uri to work (https://github.com/notEthan/jsi/pull/114)