### PR TITLE
remove support for include DescribesSchema

### DIFF
--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -177,16 +177,6 @@ module JSI
       elsif self.jsi_instance.respond_to?(:to_ary)
         extend PathedArrayNode
       end
-
-      jsi_schemas.each do |schema|
-        # if this JSI is a schema - i.e. if it is described by a (meta)schema which indicates it describes
-        # schemas - and the class doesn't already include JSI::Schema, extend self with JSI::Schema.
-        # this may be the case when a jsi schema module includes JSI::Schema::DescribesSchema without
-        # setting jsi_schema_instance_modules to include JSI::Schema
-        if !is_a?(JSI::Schema) && schema.describes_schema?
-          extend JSI::Schema
-        end
-      end
     end
 
     # document containing the instance of this JSI

--- a/lib/jsi/metaschema_node.rb
+++ b/lib/jsi/metaschema_node.rb
@@ -122,7 +122,7 @@ module JSI
       begin # draft 4 boolean schema workaround
         # in draft 4, boolean schemas are not described in the root, but on anyOf schemas on
         # properties/additionalProperties and properties/additionalItems.
-        # we need to extend those as DescribesSchema.
+        # since these describe schemas, their jsi_schema_instance_modules are the metaschema_instance_modules.
         addtlPropsanyOf = metaschema_root_ptr["properties"]["additionalProperties"]["anyOf"]
         addtlItemsanyOf = metaschema_root_ptr["properties"]["additionalItems"]["anyOf"]
 

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -268,7 +268,7 @@ module JSI
 
     # @return [Boolean] does this schema itself describe a schema?
     def describes_schema?
-      jsi_schema_instance_modules.any? { |m| m <= JSI::Schema } || is_a?(DescribesSchema)
+      jsi_schema_instance_modules.any? { |m| m <= JSI::Schema }
     end
 
     # @return [Set<Module>] modules to apply to instances described by this schema. these modules are included


### PR DESCRIPTION
including DescribesSchema is removed in favor of setting the schema's jsi_schema_instance_modules

this no longer worked as of https://github.com/notEthan/jsi/pull/121
