### PR TITLE
deprecate JSI.class_for_schemas

### DIFF
--- a/lib/jsi.rb
+++ b/lib/jsi.rb
@@ -70,11 +70,9 @@ module JSI
     JSI::Schema.new_schema(schema_object, *a).jsi_schema_module
   end
 
-  # @param schemas [Enumerable<JSI::Schema, #to_hash, Boolean>] schemas to represent with the class
-  # @return [Class subclassing JSI::Base] a JSI class which represents the given schemas.
-  #   an instance of the class represents a JSON Schema instance described by all of the given schemas.
-  def self.class_for_schemas(*schemas)
-    SchemaClasses.class_for_schemas(*schemas)
+  # @deprecated
+  def self.class_for_schemas(schemas)
+    SchemaClasses.class_for_schemas(schemas.map { |schema| JSI.new_schema(schema) })
   end
 
   # `JSI.schema_registry` is the {JSI::SchemaRegistry} in which schemas are registered.

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -281,7 +281,7 @@ module JSI
 
     # @return [Class subclassing JSI::Base] a JSI class (subclass of JSI::Base) representing this schema.
     def jsi_schema_class
-      JSI.class_for_schemas(SchemaSet[self])
+      JSI::SchemaClasses.class_for_schemas(SchemaSet[self])
     end
 
     # instantiates the given instance as a JSI::Base class for schemas matched from this schema to the

--- a/lib/jsi/schema_classes.rb
+++ b/lib/jsi/schema_classes.rb
@@ -43,9 +43,12 @@ module JSI
     extend Util::Memoize
 
     class << self
-      # see {JSI.class_for_schemas}
-      def class_for_schemas(schema_objects)
-        schemas = SchemaSet.new(schema_objects) { |schema_object| JSI.new_schema(schema_object) }
+      # @api private
+      # @param schemas [Enumerable<JSI::Schema>] schemas which the class will represent
+      # @return [Class subclassing JSI::Base] a JSI Schema Class which represents the given schemas.
+      #   an instance of the class is a JSON Schema instance described by all of the given schemas.
+      def class_for_schemas(schemas)
+        schemas = SchemaSet.ensure_schema_set(schemas)
 
         jsi_memoize(:class_for_schemas, schemas) do |schemas|
           Class.new(Base).instance_exec(schemas) do |schemas|

--- a/lib/jsi/schema_set.rb
+++ b/lib/jsi/schema_set.rb
@@ -73,7 +73,7 @@ module JSI
         each { |schema| set.merge(schema.match_to_instance(instance)) }
       end
 
-      JSI.class_for_schemas(applied_schemas).new(instance,
+      JSI::SchemaClasses.class_for_schemas(applied_schemas).new(instance,
         jsi_schema_base_uri: base_uri,
       )
     end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -58,13 +58,13 @@ describe JSI::Base do
   end
   describe '.class_for_schemas' do
     it 'returns a class from a schema' do
-      class_for_schema = JSI.class_for_schemas([schema])
+      class_for_schema = JSI::SchemaClasses.class_for_schemas([schema])
       # same class every time
-      assert_equal(JSI.class_for_schemas([schema]), class_for_schema)
+      assert_equal(JSI::SchemaClasses.class_for_schemas([schema]), class_for_schema)
       assert_operator(class_for_schema, :<, JSI::Base)
     end
-    it 'returns the same class from a hash' do
-      assert_equal(JSI.class_for_schemas([schema]), JSI.class_for_schemas([schema_content]))
+    it 'raises given a nonschema' do
+      assert_raises(JSI::Schema::NotASchemaError) { JSI::SchemaClasses.class_for_schemas([schema_content]) }
     end
   end
   describe 'JSI::SchemaClasses.module_for_schema' do

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -283,7 +283,7 @@ describe JSI::Schema do
   describe '#jsi_schema_class' do
     it 'returns the class for the schema' do
       schema = JSI.new_schema({'id' => 'https://schemas.jsi.unth.net/test/schema_schema_class'})
-      assert_equal(JSI.class_for_schemas([schema]), schema.jsi_schema_class)
+      assert_equal(JSI::SchemaClasses.class_for_schemas([schema]), schema.jsi_schema_class)
     end
   end
   describe '#subschemas_for_property_name' do


### PR DESCRIPTION
no longer an expected entry point for instantiating schemas