### PR TITLE
Schema.ensure_schema may reinstantiate nonschemas as schemas

### DIFF
--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -202,14 +202,30 @@ module JSI
       #   if the schema param is not a schema
       # @raise [NotASchemaError] if the schema param is not a schema
       # @return [Schema] the given schema
-      def ensure_schema(schema, msg: "indicated object is not a schema:")
+      def ensure_schema(schema, msg: "indicated object is not a schema:", reinstantiate_as: nil)
         if schema.is_a?(Schema)
           schema
         else
-          raise(NotASchemaError, [
-            *msg,
-            schema.pretty_inspect.chomp,
-          ].join("\n"))
+          if reinstantiate_as
+            # TODO warn; behavior is undefined and I hate this implementation
+
+            result_schema_schemas = schema.jsi_schemas + reinstantiate_as
+
+            result_schema_class = JSI::SchemaClasses.class_for_schemas(result_schema_schemas)
+
+            result_schema_class.new(Base::NOINSTANCE,
+              jsi_document: schema.jsi_document,
+              jsi_ptr: schema.jsi_ptr,
+              jsi_root_node: schema.jsi_root_node,
+              jsi_schema_base_uri: schema.jsi_schema_base_uri,
+              jsi_schema_resource_ancestors: schema.jsi_schema_resource_ancestors,
+            )
+          else
+            raise(NotASchemaError, [
+              *msg,
+              schema.pretty_inspect.chomp,
+            ].join("\n"))
+          end
         end
       end
     end

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -388,17 +388,19 @@ module JSI
           # resource_root_subschema is always relative to the document root.
           # BootstrapSchema also does not implement jsi_root_node or #[]. we instantiate the ptr directly
           # rather than as a subschema from the root.
-          result_schema = schema.class.new(
+          schema.class.new(
             schema.jsi_document,
             jsi_ptr: ptr,
             jsi_schema_base_uri: nil,
           )
         else
-          result_schema = ptr.evaluate(schema.schema_resource_root, as_jsi: true)
+          resource_root = schema.schema_resource_root
+          Schema.ensure_schema(ptr.evaluate(resource_root, as_jsi: true),
+            msg: [
+              "subschema is not a schema at pointer: #{ptr.pointer}"
+            ]
+          )
         end
-        Schema.ensure_schema(result_schema, msg: [
-          "subschema is not a schema at pointer: #{ptr.pointer}"
-        ])
       end
     end
 

--- a/lib/jsi/schema.rb
+++ b/lib/jsi/schema.rb
@@ -414,7 +414,8 @@ module JSI
           Schema.ensure_schema(ptr.evaluate(resource_root, as_jsi: true),
             msg: [
               "subschema is not a schema at pointer: #{ptr.pointer}"
-            ]
+            ],
+            reinstantiate_as: schema.jsi_schemas.select(&:describes_schema?)
           )
         end
       end

--- a/test/unsupported_test.rb
+++ b/test/unsupported_test.rb
@@ -47,6 +47,22 @@ describe 'unsupported behavior' do
           )
         end
       end
+      describe 'below nonschema root' do
+        it "instantiates" do
+          schema_doc_schema = JSI::JSONSchemaOrgDraft04.new_schema({
+            'properties' => {'schema' => {'$ref' => 'http://json-schema.org/draft-04/schema'}}
+          })
+          schema_doc = schema_doc_schema.new_jsi({
+            'schema' => {'$ref' => '#/unknown'},
+            'unknown' => {},
+          })
+          subject = schema_doc.schema.new_jsi({})
+          assert_equal(
+            [JSI::Ptr["unknown"]],
+            subject.jsi_schemas.map(&:jsi_ptr)
+          )
+        end
+      end
     end
   end
 end

--- a/test/unsupported_test.rb
+++ b/test/unsupported_test.rb
@@ -5,4 +5,48 @@ require_relative 'test_helper'
 # the behavior described in these tests is not officially supported, but is not expected to break.
 
 describe 'unsupported behavior' do
+  let(:schema) { JSI.new_schema(schema_content) }
+  let(:instance) { {} }
+  let(:subject) { schema.new_jsi(instance) }
+
+  describe 'JSI::Schema' do
+    # reinstantiating objects at unrecognized paths as schemas is implemented but I don't want to officially
+    # support it. the spec states that the behavior is undefined, and the code implementing it is brittle,
+    # ugly, and prone to breakage, particularly with $id.
+    describe 'reinstantiation' do
+      describe 'below another schema' do
+        let(:schema_content) do
+          YAML.safe_load(<<~YAML
+            definitions:
+              a:
+                $id: http://jsi/test/reinstantiation/below_another/a
+                definitions:
+                  sub:
+                    {}
+                unknown:
+                  definitions:
+                    b:
+                      additionalProperties:
+                        $ref: "#/definitions/sub"
+            items:
+              $ref: "#/definitions/a/unknown/definitions/b"
+            YAML
+          )
+        end
+        let(:instance) do
+          [{'x' => {}}]
+        end
+        it "instantiates" do
+          assert_equal(
+            [JSI::Ptr["definitions", "a", "unknown", "definitions", "b"]],
+            subject[0].jsi_schemas.map(&:jsi_ptr)
+          )
+          assert_equal(
+            [JSI::Ptr["definitions", "a", "definitions", "sub"]],
+            subject[0]['x'].jsi_schemas.map(&:jsi_ptr)
+          )
+        end
+      end
+    end
+  end
 end

--- a/test/unsupported_test.rb
+++ b/test/unsupported_test.rb
@@ -63,6 +63,27 @@ describe 'unsupported behavior' do
           )
         end
       end
+      describe 'the origin schema has schemas that do not describe a schema (items)' do
+        let(:schema_content) do
+          {
+            'items' => {'$ref' => '#/unknown'},
+            'unknown' => {},
+          }
+        end
+        let(:instance) do
+          [{}]
+        end
+        it "instantiates" do
+          assert_equal(
+            [JSI::Ptr["unknown"]],
+            subject[0].jsi_schemas.map(&:jsi_ptr)
+          )
+          unknown_schema = subject[0].jsi_schemas.to_a[0]
+          # check it's not an items schema like schema.items is
+          assert_equal(schema.jsi_schemas, unknown_schema.jsi_schemas)
+          refute_equal(schema.items.jsi_schemas, unknown_schema.jsi_schemas)
+        end
+      end
     end
   end
 end

--- a/test/unsupported_test.rb
+++ b/test/unsupported_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+# the behavior described in these tests is not officially supported, but is not expected to break.
+
+describe 'unsupported behavior' do
+end


### PR DESCRIPTION
unsupported. undocumented. unwanted.