### PR TITLE
Invalid application

### DIFF
--- a/lib/jsi/schema/application/child_application/contains.rb
+++ b/lib/jsi/schema/application/child_application/contains.rb
@@ -7,8 +7,20 @@ module JSI
       if keyword?('contains')
         contains_schema = subschema(['contains'])
 
-        if contains_schema.instance_valid?(instance[idx])
+        child_idx_valid = {}
+        instance.each_index do |i|
+          child_idx_valid[i] = contains_schema.instance_valid?(instance[i])
+        end
+
+        if child_idx_valid[idx]
           yield contains_schema
+        else
+          instance_valid = child_idx_valid.values.any? { |v| v }
+
+          unless instance_valid
+            # invalid application: if contains_schema does not validate against any child, it applies to every child
+            yield contains_schema
+          end
         end
       end
     end

--- a/lib/jsi/schema/application/child_application/contains.rb
+++ b/lib/jsi/schema/application/child_application/contains.rb
@@ -7,15 +7,12 @@ module JSI
       if keyword?('contains')
         contains_schema = subschema(['contains'])
 
-        child_idx_valid = {}
-        instance.each_index do |i|
-          child_idx_valid[i] = contains_schema.instance_valid?(instance[i])
-        end
+        child_idx_valid = Hash.new { |h, i| h[i] = contains_schema.instance_valid?(instance[i]) }
 
         if child_idx_valid[idx]
           yield contains_schema
         else
-          instance_valid = child_idx_valid.values.any? { |v| v }
+          instance_valid = instance.each_index.any? { |i| child_idx_valid[i] }
 
           unless instance_valid
             # invalid application: if contains_schema does not validate against any child, it applies to every child

--- a/test/base_mutation_test.rb
+++ b/test/base_mutation_test.rb
@@ -52,8 +52,8 @@ describe JSI::Base do
 
       subject.ab = {'type' => 'c'}
       refute(subject.jsi_valid?)
-      refute_schema(schema.definitions['a'], subject.ab)
-      refute_schema(schema.definitions['b'], subject.ab)
+      assert_schema(schema.definitions['a'], subject.ab)
+      assert_schema(schema.definitions['b'], subject.ab)
     end
   end
 

--- a/test/schema_child_application_test.rb
+++ b/test/schema_child_application_test.rb
@@ -108,11 +108,13 @@ describe 'JSI Schema child application' do
           )
         end
         let(:instance) { [{}, {}] }
-        it 'does not apply' do
-          assert_schemas([], subject[0])
-          assert_schemas([], subject[1])
-          refute_is_a(schema.contains.jsi_schema_module, subject[0])
-          refute_is_a(schema.contains.jsi_schema_module, subject[1])
+        it 'applies' do
+          assert_schemas([
+            schema.contains,
+          ], subject[0])
+          assert_schemas([
+            schema.contains,
+          ], subject[1])
         end
       end
     end

--- a/test/schema_inplace_application_test.rb
+++ b/test/schema_inplace_application_test.rb
@@ -157,8 +157,8 @@ describe 'JSI Schema inplace application' do
             schema.allOf[0].allOf[0],
             schema.allOf[0].allOf[1],
             schema.allOf[1],
+            schema.allOf[1].oneOf[0],
           ], subject)
-          refute_is_a(schema.allOf[1].oneOf[0].jsi_schema_module, subject)
         end
       end
       describe 'anyOf' do
@@ -220,15 +220,15 @@ describe 'JSI Schema inplace application' do
           )
         end
         let(:instance) { {} }
-        it 'applies none' do
+        it 'applies all' do
           assert_schemas([
             schema,
+            schema.anyOf[0],
+            schema.anyOf[0].anyOf[0],
+            schema.anyOf[0].anyOf[1],
+            schema.anyOf[1],
+            schema.anyOf[1].oneOf[0],
           ], subject)
-          refute_is_a(schema.anyOf[0].jsi_schema_module, subject)
-          refute_is_a(schema.anyOf[0].anyOf[0].jsi_schema_module, subject)
-          refute_is_a(schema.anyOf[0].anyOf[1].jsi_schema_module, subject)
-          refute_is_a(schema.anyOf[1].jsi_schema_module, subject)
-          refute_is_a(schema.anyOf[1].oneOf[0].jsi_schema_module, subject)
         end
       end
       describe 'oneOf' do
@@ -292,15 +292,15 @@ describe 'JSI Schema inplace application' do
           )
         end
         let(:instance) { {} }
-        it 'applies none' do
+        it 'applies all' do
           assert_schemas([
             schema,
+            schema.oneOf[0],
+            schema.oneOf[0].oneOf[0],
+            schema.oneOf[0].oneOf[1],
+            schema.oneOf[1],
+            schema.oneOf[1].allOf[0],
           ], subject)
-          refute_is_a(schema.oneOf[0].jsi_schema_module, subject)
-          refute_is_a(schema.oneOf[0].oneOf[0].jsi_schema_module, subject)
-          refute_is_a(schema.oneOf[0].oneOf[1].jsi_schema_module, subject)
-          refute_is_a(schema.oneOf[1].jsi_schema_module, subject)
-          refute_is_a(schema.oneOf[1].allOf[0].jsi_schema_module, subject)
         end
       end
     end


### PR DESCRIPTION
schemas whose application depends on validation results should apply when the validation fails, so that checking the validity of children will not incorrectly return valid due to not having the failing schema applied to validate against 
