### PR TITLE
`Base#[]` param `use_default` default `false`, overridable

### DIFF
--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -467,9 +467,22 @@ module JSI
     #   (one exception is when this JSI's instance is a Hash with a default or default_proc, which has
     #   unspecified behavior.)
     # @return [JSI::Base, Object, nil] the child value identified by the subscript token
-    def [](token, as_jsi: :auto, use_default: true)
+    def [](token, as_jsi: jsi_child_as_jsi_default, use_default: jsi_child_use_default_default)
       # note: overridden by Base::HashNode, Base::ArrayNode
       jsi_simple_node_child_error(token)
+    end
+
+    # The default value for the param `as_jsi` of {#[]}, controlling whether a child is returned as a JSI instance.
+    # @return [:auto, true, false] a valid value of the `as_jsi` param of {#[]}
+    def jsi_child_as_jsi_default
+      :auto
+    end
+
+    # The default value for the param `use_default` of {#[]}, controlling whether a schema default value is
+    # returned when a token refers to a child that is not in the document.
+    # @return [true, false] a valid value of the `use_default` param of {#[]}
+    def jsi_child_use_default_default
+      true
     end
 
     # assigns the subscript of the instance identified by the given token to the given value.

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -482,7 +482,7 @@ module JSI
     # returned when a token refers to a child that is not in the document.
     # @return [true, false] a valid value of the `use_default` param of {#[]}
     def jsi_child_use_default_default
-      true
+      false
     end
 
     # assigns the subscript of the instance identified by the given token to the given value.

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -437,9 +437,10 @@ module JSI
     #
     # @param token [String, Integer, Object] an array index or hash key (JSON object property name)
     #   of the instance identifying the child value
-    # @param as_jsi [:auto, true, false] whether to return the result value as a JSI. one of:
+    # @param as_jsi [:auto, true, false] (default is `:auto`)
+    #   Whether to return the child as a JSI. One of:
     #
-    #   - :auto (default): by default a JSI will be returned when either:
+    #   - `:auto`: By default a JSI will be returned when either:
     #
     #     - the result is a complex value (responds to #to_ary or #to_hash)
     #     - the result is a schema (including true/false schemas)
@@ -454,8 +455,9 @@ module JSI
     #   is not a hash key or array index of the instance and no default value applies.
     #   (one exception is when this JSI's instance is a Hash with a default or default_proc, which has
     #   unspecified behavior.)
-    # @param use_default [true, false] whether to return a schema default value when the token is not in
-    #   range. if the token is not an array index or hash key of the instance, and one schema for the child
+    # @param use_default [true, false] (default is `false`)
+    #   Whether to return a schema default value when the token refers to a child that is not in the document.
+    #   If the token is not an array index or hash key of the instance, and one schema for the child
     #   instance specifies a default value, that default is returned.
     #
     #   if the result with the default value is a JSI (per the `as_jsi` param), that JSI is not a child of

--- a/lib/jsi/base.rb
+++ b/lib/jsi/base.rb
@@ -380,7 +380,7 @@ module JSI
     # @param token (see Base#[])
     # @param as_jsi (see Base#[])
     # @return [JSI::Base, Object]
-    def jsi_child(token, as_jsi: :auto)
+    def jsi_child(token, as_jsi: )
       child_content = jsi_node_content_child(token)
 
       child_indicated_schemas = jsi_schemas.child_applicator_schemas(token, jsi_node_content)
@@ -408,7 +408,7 @@ module JSI
     # @param token (see Base#[])
     # @param as_jsi (see Base#[])
     # @return [JSI::Base, nil]
-    def jsi_default_child(token, as_jsi: :auto)
+    def jsi_default_child(token, as_jsi: )
       child_content = jsi_node_content_child(token)
 
       child_indicated_schemas = jsi_schemas.child_applicator_schemas(token, jsi_node_content)

--- a/lib/jsi/base/node.rb
+++ b/lib/jsi/base/node.rb
@@ -84,7 +84,7 @@ module JSI
     end
 
     # See {Base#[]}
-    def [](token, as_jsi: :auto, use_default: true)
+    def [](token, as_jsi: jsi_child_as_jsi_default, use_default: jsi_child_use_default_default)
       if jsi_node_content_hash_pubsend(:key?, token)
         jsi_child(token, as_jsi: as_jsi)
       else
@@ -201,7 +201,7 @@ module JSI
     end
 
     # See {Base#[]}
-    def [](token, as_jsi: :auto, use_default: true)
+    def [](token, as_jsi: jsi_child_as_jsi_default, use_default: jsi_child_use_default_default)
       size = jsi_node_content_ary_pubsend(:size)
       if token.is_a?(Integer)
         if token < 0

--- a/lib/jsi/metaschema_node.rb
+++ b/lib/jsi/metaschema_node.rb
@@ -148,7 +148,7 @@ module JSI
     attr_reader :jsi_schemas
 
     # see {Base#jsi_child}
-    def jsi_child(token, as_jsi: :auto)
+    def jsi_child(token, as_jsi: )
       child_node = jsi_child_node_map[token: token]
 
       jsi_child_as_jsi(jsi_node_content_child(token), child_node.jsi_schemas, as_jsi) do

--- a/test/base_array_test.rb
+++ b/test/base_array_test.rb
@@ -52,6 +52,9 @@ describe 'JSI::Base array' do
         'items' => {'default' => 'foo'},
       }
     end
+
+    schema_instance_child_use_default_default_true
+
     describe 'default value' do
       let(:instance) { [1] }
       it 'returns the default value' do
@@ -93,6 +96,9 @@ describe 'JSI::Base array' do
         'items' => {'default' => {'foo' => 2}},
       }
     end
+
+    schema_instance_child_use_default_default_true
+
     describe 'default value' do
       let(:instance) { [{'bar' => 3}] }
       it 'returns the default value' do

--- a/test/base_hash_test.rb
+++ b/test/base_hash_test.rb
@@ -25,6 +25,9 @@ describe 'JSI::Base hash' do
         },
       }
     end
+
+    schema_instance_child_use_default_default_true
+
     describe 'default value' do
       let(:instance) { {'bar' => 3} }
       it 'returns the default value' do
@@ -56,6 +59,9 @@ describe 'JSI::Base hash' do
         },
       }
     end
+
+    schema_instance_child_use_default_default_true
+
     describe 'default value' do
       let(:instance) { {'bar' => 3} }
       it 'returns the default value' do
@@ -88,6 +94,9 @@ describe 'JSI::Base hash' do
         },
       }
     end
+
+    schema_instance_child_use_default_default_true
+
     describe 'default value' do
       let(:instance) { Hash.new({'foo' => 2}).merge({'bar' => 3}) }
       it 'returns the default value' do

--- a/test/jsi_helper.rb
+++ b/test/jsi_helper.rb
@@ -47,3 +47,18 @@ class SortOfArray
     {class: self.class, ary: @ary}
   end
 end
+
+class Module
+  def redef_method(method_name, method = nil, &block)
+    begin
+      remove_method(method_name)
+    rescue NameError
+    end
+
+    if method
+      define_method(method_name, method, &block)
+    else
+      define_method(method_name, &block)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -138,6 +138,10 @@ class JSISpec < Minitest::Spec
     # :nocov:
   end
 
+  def self.schema_instance_child_use_default_default_true
+    before { schema.jsi_schema_module_exec { redef_method(:jsi_child_use_default_default) { true } } }
+  end
+
   def assert_equal exp, act, msg = nil
     msg = message(msg, E) do
       [].tap do |ms|


### PR DESCRIPTION
defaulting to insert schema default values is confusing if you're not expecting it. certain metaschemas having a default of `{}` or `true` in particular leads to masked bugs.